### PR TITLE
Update docs

### DIFF
--- a/PureMVC/core/Controller.m
+++ b/PureMVC/core/Controller.m
@@ -77,6 +77,7 @@ registrations.
 */
 + (id<IController>)getInstance:(NSString *)key factory:(id<IController> (^)(NSString *key))factory {
     @synchronized (instanceMap) {
+        // The Multiton Controller instanceMap.
         if (instanceMap[key] == nil) {
             instanceMap[key] = factory(key);
         }
@@ -90,6 +91,7 @@ registrations.
     }
 }
 
+/// The Multiton Key for this app
 + (instancetype)withKey:(NSString *)key {
     return [[Controller alloc] initWithKey:key];
 }
@@ -107,6 +109,7 @@ passing the unique key for this instance
 */
 - (instancetype)initWithKey:(NSString *)key {
     if (instanceMap[key] != nil) {
+        // Message constant
         [NSException raise:@"ControllerAlreadyExistsException" format:@"A Controller instance already exists for key '%@'.", key];
     }
     if (self = [super init]) {

--- a/PureMVC/core/Controller.m
+++ b/PureMVC/core/Controller.m
@@ -68,6 +68,13 @@ registrations.
 */
 @implementation Controller
 
+/**
+`Controller` Multiton Factory method.
+
+- parameter key: multitonKey
+- parameter factory: reference that returns `IController`
+- returns: the Multiton instance
+*/
 + (id<IController>)getInstance:(NSString *)key factory:(id<IController> (^)(NSString *key))factory {
     @synchronized (instanceMap) {
         if (instanceMap[key] == nil) {
@@ -87,6 +94,17 @@ registrations.
     return [[Controller alloc] initWithKey:key];
 }
 
+/**
+Constructor.
+
+This `IController` implementation is a Multiton,
+so you should not call the constructor
+directly, but instead call the static Factory method,
+passing the unique key for this instance
+`Controller.getInstance(multitonKey) { key in Controller(key: key) }`
+
+@throws Error if instance for this Multiton key has already been constructed
+*/
 - (instancetype)initWithKey:(NSString *)key {
     if (instanceMap[key] != nil) {
         [NSException raise:@"ControllerAlreadyExistsException" format:@"A Controller instance already exists for key '%@'.", key];
@@ -120,9 +138,23 @@ following way:
     self.view = [View getInstance:self.multitonKey factory:^(NSString *key){ return [View withKey:key]; }];
 }
 
+/**
+Register a particular `ICommand` class as the handler
+for a particular `INotification`.
+
+If an `ICommand` has already been registered to
+handle `INotification`s with this name, it is no longer
+used, the new `ICommand` is used instead.
+
+The Observer for the new ICommand is only created if this the
+first time an ICommand has been regisered for this Notification name.
+
+- parameter notificationName: the name of the `INotification`
+- parameter factory: reference that returns `ICommand`
+*/
 - (void)registerCommand:(NSString *)notificationName factory:(id<ICommand> (^)(void))factory {
     dispatch_barrier_sync(self.commandMapQueue, ^{
-        if (self.commandMap[notificationName] == nil) {
+        if (self.commandMap[notificationName] == nil) { // weak reference to Controller (self) to avoid reference cycle with View and Observer
             id<IObserver> observer = [Observer withNotify:@selector(executeCommand:) context: self];
             [self.view registerObserver:notificationName observer:observer];
         }
@@ -130,6 +162,12 @@ following way:
     });
 }
 
+/**
+If an `ICommand` has previously been registered
+to handle a the given `INotification`, then it is executed.
+
+- parameter notification: an `INotification`
+*/
 - (void)executeCommand:(id<INotification>)notification {
     __block id<ICommand> (^factory)(void) = nil;
     dispatch_sync(self.commandMapQueue, ^{
@@ -141,6 +179,12 @@ following way:
     [command execute:notification];
 }
 
+/**
+Check if a Command is registered for a given Notification
+
+- parameter notificationName:
+- returns: whether a Command is currently registered for the given `notificationName`.
+*/
 - (BOOL)hasCommand:(NSString *)notificationName {
     __block BOOL exists = NO;
     dispatch_sync(self.commandMapQueue, ^{
@@ -149,6 +193,11 @@ following way:
     return exists;
 }
 
+/**
+Remove a previously registered `ICommand` to `INotification` mapping.
+
+- parameter notificationName: the name of the `INotification` to remove the `ICommand` mapping for
+*/
 - (void)removeCommand:(NSString *)notificationName {
     dispatch_barrier_sync(self.commandMapQueue, ^{
         if (self.commandMap[notificationName] != nil) {

--- a/PureMVC/core/Model.m
+++ b/PureMVC/core/Model.m
@@ -93,13 +93,20 @@ Factory method `Model.getInstance( multitonKey )`
 @throws Error if instance for this Multiton key instance has already been constructed
 */
 - (instancetype)initWithKey:(NSString *)key {
+    // The Multiton Model instanceMap
     if (instanceMap[key] != nil) {
+        // Message constant
         [NSException raise:@"ModelAlreadyExistsException" format:@"A Model instance already exists for key '%@'.", key];
     }
     if (self = [super init]) {
         _multitonKey = [key copy];
         [instanceMap setObject:self forKey:key];
+        
+        // Mapping of proxyNames to IProxy instances
         _proxyMap = [NSMutableDictionary dictionary];
+        
+        // Concurrent queue for proxyMap
+        // for speed and convenience of running concurrently while reading, and thread safety of blocking while mutating
         _proxyMapQueue = dispatch_queue_create("org.puremvc.model.proxyMapQueue", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;

--- a/PureMVC/core/Model.m
+++ b/PureMVC/core/Model.m
@@ -26,8 +26,36 @@ static void initialize(void) {
     instanceMap = [NSMutableDictionary dictionary];
 }
 
+/**
+A Multiton `IModel` implementation.
+
+In PureMVC, the `Model` class provides
+access to model objects (Proxies) by named lookup.
+
+The `Model` assumes these responsibilities:
+
+* Maintain a cache of `IProxy` instances.
+* Provide methods for registering, retrieving, and removing `IProxy` instances.
+
+Your application must register `IProxy` instances
+with the `Model`. Typically, you use an
+`ICommand` to create and register `IProxy`
+instances once the `Facade` has initialized the Core
+actors.
+
+`@see org.puremvc.swift.multicore.patterns.proxy.Proxy Proxy`
+
+`@see org.puremvc.swift.multicore.interfaces.IProxy IProxy`
+*/
 @implementation Model
 
+/**
+`Model` Multiton Factory method.
+
+- parameter key: multitonKey
+- parameter factory: reference that returns `IModel`
+- returns: the instance returned by the passed closure
+*/
 + (id<IModel>)getInstance:(NSString *)key factory:(id<IModel> (^)(NSString *key))factory {
     @synchronized (instanceMap) {
         if (instanceMap[key] == nil) {
@@ -37,6 +65,11 @@ static void initialize(void) {
     }
 }
 
+/**
+Remove an IModel instance
+
+- parameter key: of IModel instance to remove
+*/
 + (void)removeModel:(NSString *)key {
     @synchronized (instanceMap) {
         [instanceMap removeObjectForKey:key];
@@ -47,6 +80,18 @@ static void initialize(void) {
     return [[Model alloc] initWithKey:key];
 }
 
+/**
+Constructor.
+
+This `IModel` implementation is a Multiton,
+so you should not call the constructor
+directly, but instead call the static Multiton
+Factory method `Model.getInstance( multitonKey )`
+
+- parameter key: multitonKey
+
+@throws Error if instance for this Multiton key instance has already been constructed
+*/
 - (instancetype)initWithKey:(NSString *)key {
     if (instanceMap[key] != nil) {
         [NSException raise:@"ModelAlreadyExistsException" format:@"A Model instance already exists for key '%@'.", key];
@@ -60,6 +105,11 @@ static void initialize(void) {
     return self;
 }
 
+/**
+Register an `IProxy` with the `Model`.
+
+- parameter proxy: an `IProxy` to be held by the `Model`.
+*/
 - (void)registerProxy:(id<IProxy>)proxy {
     // [proxy initializeNotifier(multitonKey)]
     dispatch_barrier_sync(self.proxyMapQueue, ^{
@@ -68,6 +118,12 @@ static void initialize(void) {
     [proxy onRegister];
 }
 
+/**
+Retrieve an `IProxy` from the `Model`.
+
+- parameter proxyName:
+- returns: the `IProxy` instance previously registered with the given `proxyName`.
+*/
 - (nullable id<IProxy>)retrieveProxy:(NSString *)proxyName {
     __block id<IProxy> proxy = nil;
     dispatch_sync(self.proxyMapQueue, ^{
@@ -76,6 +132,12 @@ static void initialize(void) {
     return proxy;
 }
 
+/**
+Check if a Proxy is registered
+
+- parameter proxyName:
+- returns: whether a Proxy is currently registered with the given `proxyName`.
+*/
 - (BOOL)hasProxy:(NSString *)proxyName {
     __block BOOL exists = NO;
     dispatch_sync(self.proxyMapQueue, ^{
@@ -84,6 +146,12 @@ static void initialize(void) {
     return exists;
 }
 
+/**
+Remove an `IProxy` from the `Model`.
+
+- parameter proxyName: name of the `IProxy` instance to be removed.
+- returns: the `IProxy` that was removed from the `Model`
+*/
 - (nullable id<IProxy>)removeProxy:(NSString *)proxyName {
     __block id<IProxy> proxy = nil;
     dispatch_barrier_sync(self.proxyMapQueue, ^{

--- a/PureMVC/core/View.m
+++ b/PureMVC/core/View.m
@@ -31,8 +31,34 @@ static void initialize(void) {
     instanceMap = [NSMutableDictionary dictionary];
 }
 
+/**
+A Multiton `IView` implementation.
+
+In PureMVC, the `View` class assumes these responsibilities:
+
+* Maintain a cache of `IMediator` instances.
+* Provide methods for registering, retrieving, and removing `IMediators`.
+* Notifiying `IMediators` when they are registered or removed.
+* Managing the observer lists for each `INotification` in the application.
+* Providing a method for attaching `IObservers` to an `INotification`'s observer list.
+* Providing a method for broadcasting an `INotification`.
+* Notifying the `IObservers` of a given `INotification` when it broadcast.
+
+`@see org.puremvc.swift.multicore.patterns.mediator.Mediator Mediator`
+
+`@see org.puremvc.swift.multicore.patterns.observer.Observer Observer`
+
+`@see org.puremvc.swift.multicore.patterns.observer.Notification Notification`
+*/
 @implementation View
 
+/**
+View Multiton Factory method.
+
+- parameter key: multitonKey
+- parameter factory: reference that returns `IView`
+- returns: the Multiton instance returned by executing the passed closure
+*/
 + (id<IView>)getInstance:(NSString *)key factory:(id<IView> (^)(NSString *key))factory {
     @synchronized (instanceMap) {
         if (instanceMap[key] == nil) {
@@ -42,6 +68,11 @@ static void initialize(void) {
     }
 }
 
+/**
+Remove an IView instance
+
+- parameter key: of IView instance to remove
+*/
 + (void)removeView:(NSString *)key {
     @synchronized (instanceMap) {
         [instanceMap removeObjectForKey:key];
@@ -52,6 +83,18 @@ static void initialize(void) {
     return [[View alloc] initWithKey:key];
 }
 
+/**
+Constructor.
+
+This `IView` implementation is a Multiton,
+so you should not call the constructor
+directly, but instead call the static Multiton
+Factory method `View.getInstance( multitonKey )`
+
+- parameter key: multitonKey
+
+@throws Error if instance for this Multiton key has already been constructed
+*/
 - (instancetype)initWithKey:(NSString *)key {
     if (instanceMap[key] != nil) {
         [NSException raise:@"ViewAlreadyExistsException" format:@"A View instance already exists for key '%@'.", key];
@@ -67,6 +110,13 @@ static void initialize(void) {
     return self;
 }
 
+/**
+Register an `IObserver` to be notified
+of `INotifications` with a given name.
+
+- parameter notificationName: the name of the `INotifications` to notify this `IObserver` of
+- parameter observer: the `IObserver` to register
+*/
 - (void)registerObserver:(NSString *)notificationName observer:(id<IObserver>)observer {
     dispatch_barrier_sync(self.observerMapQueue, ^{
         if (self.observerMap[notificationName] != nil) {
@@ -77,7 +127,15 @@ static void initialize(void) {
     });
 }
 
+/**
+Notify the `IObservers` for a particular `INotification`.
 
+All previously attached `IObservers` for this `INotification`'s
+list are notified and are passed a reference to the `INotification` in
+the order in which they were registered.
+
+- parameter notification: the `INotification` to notify `IObservers` of.
+*/
 - (void)notifyObservers:(id<INotification>)notification {
     __block NSArray<id<IObserver>> *observers = nil;
     dispatch_sync(self.observerMapQueue, ^{
@@ -91,27 +149,57 @@ static void initialize(void) {
     }
 }
 
+/**
+Remove the observer for a given notifyContext from an observer list for a given Notification name.
+
+- parameter notificationName: which observer list to remove from
+- parameter notifyContext: remove the observer with this object as its notifyContext
+*/
 - (void)removeObserver:(NSString *)notificationName context:(id)context {
     dispatch_barrier_sync(self.observerMapQueue, ^{
+        // the observer list for the notification under inspection
         NSMutableArray<id<IObserver>> *observers = self.observerMap[notificationName];
         
+        // find the observer for the notifyContext
         for (id<IObserver> observer in observers) {
             if ([observer compareNotifyContext:context]) {
+                // there can only be one Observer for a given notifyContext
+                // in any given Observer list, so remove it and break
                 [observers removeObject:observer];
                 break;
             }
         }
+        
+        // Also, when a Notification's Observer list length falls to
+        // zero, delete the notification key from the observer map
         if ([observers count] == 0) {
             [self.observerMap removeObjectForKey:notificationName];
         }
     });
 }
 
+/**
+Register an `IMediator` instance with the `View`.
+
+Registers the `IMediator` so that it can be retrieved by name,
+and further interrogates the `IMediator` for its
+`INotification` interests.
+
+If the `IMediator` returns any `INotification`
+names to be notified about, an `Observer` is created encapsulating
+the `IMediator` instance's `handleNotification` method
+and registering it as an `Observer` for all `INotifications` the
+`IMediator` is interested in.
+
+- parameter mediator: a reference to the `IMediator` instance
+*/
 - (void)registerMediator:(id<IMediator>)mediator {
     __block BOOL exists = NO;
     dispatch_barrier_sync(self.mediatorMapQueue, ^{
+        // do not allow re-registration (you must to removeMediator fist)
         exists = self.mediatorMap[mediator.name] != nil;
         if (!exists)
+            // Register the Mediator for retrieval by name
             self.mediatorMap[mediator.name] = mediator;
     });
     
@@ -119,16 +207,25 @@ static void initialize(void) {
     
     // [mediator initializeNotifier:multitonKey];
     
+    // Create Observer referencing this mediator's handleNotification method
     id<IObserver> observer = [Observer withNotify:@selector(handleNotification:) context:mediator];
     
     NSArray *interests = [mediator listNotificationInterests];
+    // Register Mediator as an observer for each notification of interests
     for (NSString *notificationName in interests) {
         [self registerObserver:notificationName observer:observer];
     }
     
+    // alert the mediator that it has been registered
     [mediator onRegister];
 }
 
+/**
+Retrieve an `IMediator` from the `View`.
+
+- parameter mediatorName: the name of the `IMediator` instance to retrieve.
+- returns: the `IMediator` instance previously registered with the given `mediatorName`.
+*/
 - (nullable id<IMediator>)retrieveMediator:(NSString *)mediatorName {
     __block id<IMediator> mediator = nil;
     dispatch_sync(self.mediatorMapQueue, ^{
@@ -137,6 +234,12 @@ static void initialize(void) {
     return mediator;
 }
 
+/**
+Check if a Mediator is registered or not
+
+- parameter mediatorName:
+- returns: whether a Mediator is registered with the given `mediatorName`.
+*/
 - (BOOL)hasMediator:(NSString *)mediatorName {
     __block BOOL exists = NO;
     dispatch_sync(self.mediatorMapQueue, ^{
@@ -145,20 +248,31 @@ static void initialize(void) {
     return exists;
 }
 
+/**
+Remove an `IMediator` from the `View`.
+
+- parameter mediatorName: name of the `IMediator` instance to be removed.
+- returns: the `IMediator` that was removed from the `View`
+*/
 - (nullable id<IMediator>)removeMediator:(NSString *)mediatorName {
     __block id<IMediator> mediator = nil;
     dispatch_barrier_sync(self.mediatorMapQueue, ^{
+        // remove the mediator from the map
         mediator = self.mediatorMap[mediatorName];
         [self.mediatorMap removeObjectForKey:mediatorName];
     });
     
     if (mediator == nil) return nil;
     
+    // for every notification this mediator is interested in...
     NSArray *interests = [mediator listNotificationInterests];
     for (NSString *notificationName in interests) {
+        // remove the observer linking the mediator
+        // to the notification interest
         [self removeObserver:notificationName context:mediator];
     }
     
+    // alert the mediator that it has been removed
     [mediator onRemove];
     return mediator;
 }

--- a/PureMVC/core/View.m
+++ b/PureMVC/core/View.m
@@ -100,11 +100,19 @@ Factory method `View.getInstance( multitonKey )`
         [NSException raise:@"ViewAlreadyExistsException" format:@"A View instance already exists for key '%@'.", key];
     }
     if (self = [super init]) {
+        // The Multiton Key for this app
         _multitonKey = [key copy];
+        // The Multiton View instanceMap.
         [instanceMap setObject:self forKey:key];
+        // Mapping of Mediator names to Mediator instances
         _mediatorMap = [NSMutableDictionary dictionary];
+        // Concurrent queue for mediatorMap
+        // for speed and convenience of running concurrently while reading, and thread safety of blocking while mutating
         _mediatorMapQueue = dispatch_queue_create("org.puremvc.view.mediatorMapQueue", DISPATCH_QUEUE_CONCURRENT);
+        // Mapping of Notification names to Observer lists
         _observerMap = [NSMutableDictionary dictionary];
+        // Concurrent queue for observerMap
+        // for speed and convenience of running concurrently while reading, and thread safety of blocking while mutating
         _observerMapQueue = dispatch_queue_create("org.puremvc.view.observerMapQueue", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;

--- a/PureMVC/headers/Controller.h
+++ b/PureMVC/headers/Controller.h
@@ -21,6 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype) withKey:(NSString *)key;
 
 - (instancetype) initWithKey:(NSString *)key;
+
+/**
+ Initialize the `Controller` instance.
+ */
 - (void)initializeController;
 
 @end

--- a/PureMVC/headers/ICommand.h
+++ b/PureMVC/headers/ICommand.h
@@ -15,8 +15,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Command.
+
+`@see org.puremvc.swift.multicore.interfaces INotification
+*/
 @protocol ICommand <INotifier>
 
+/**
+Execute the `ICommand`'s logic to handle a given `INotification`.
+
+- parameter notification: an `INotification` to handle.
+*/
 - (void)execute:(id<INotification>)notification;
 
 @end

--- a/PureMVC/headers/IController.h
+++ b/PureMVC/headers/IController.h
@@ -15,14 +15,54 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Controller.
+
+In PureMVC, an `IController` implementor
+follows the 'Command and Controller' strategy, and
+assumes these responsibilities:
+
+* Remembering which `ICommand`s are intended to handle which `INotifications`.
+* Registering itself as an `IObserver` with the `View` for each `INotification` that it has an `ICommand` mapping for.
+* Creating a new instance of the proper `ICommand` to handle a given `INotification` when notified by the `View`.
+* Calling the `ICommand`'s `execute` method, passing in the `INotification`.
+
+`@see org.puremvc.swift.multicore.interfaces INotification`
+
+`@see org.puremvc.swift.multicore.interfaces ICommand`
+*/
 @protocol IController
 
+/**
+Register a particular `ICommand` class as the handler
+for a particular `INotification`.
+
+- parameter notificationName: the name of the `INotification`
+- parameter factory: reference that returns `ICommand`
+*/
 - (void)registerCommand:(NSString *)notificationName factory:(id<ICommand> (^)(void))factory;
 
+/**
+Execute the `ICommand` previously registered as the
+handler for `INotification`s with the given notification name.
+
+- parameter notification: the `INotification` to execute the associated `ICommand` for
+*/
 - (void)executeCommand:(id<INotification>)notification;
 
+/**
+Check if a Command is registered for a given Notification
+
+- parameter notificationName:
+- returns: whether a Command is currently registered for the given `notificationName`.
+*/
 - (BOOL)hasCommand:(NSString *)notificationName;
 
+/**
+Remove a previously registered `ICommand` to `INotification` mapping.
+
+- parameter notificationName: the name of the `INotification` to remove the `ICommand` mapping for
+*/
 - (void)removeCommand:(NSString *)notificationName;
 
 @end

--- a/PureMVC/headers/IFacade.h
+++ b/PureMVC/headers/IFacade.h
@@ -18,22 +18,127 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Facade.
+
+The Facade Pattern suggests providing a single
+class to act as a central point of communication
+for a subsystem.
+
+In PureMVC, the Facade acts as an interface between
+the core MVC actors (Model, View, Controller) and
+the rest of your application.
+
+`@see org.puremvc.swift.multicore.interfaces.IModel IModel`
+
+`@see org.puremvc.swift.multicore.interfaces.IView IView`
+
+`@see org.puremvc.swift.multicore.interfaces.IController IController`
+
+`@see org.puremvc.swift.multicore.interfaces.ICommand ICommand`
+
+`@see org.puremvc.swift.multicore.interfaces.INotification INotification`
+*/
 @protocol IFacade <INotifier>
 
+/**
+Register an `ICommand` with the `Controller`.
+
+- parameter notificationName: the name of the `INotification` to associate the `ICommand` with.
+- parameter factory: closure that returns `ICommand`
+*/
 - (void)registerCommand:(NSString *)notificationName factory:(id<ICommand> (^)(void))factory;
+
+/**
+Check if a Command is registered for a given Notification
+
+- parameter notificationName:
+- returns: whether a Command is currently registered for the given `notificationName`.
+*/
 - (BOOL)hasCommand:(NSString *)notificationName;
+
+/**
+Remove a previously registered `ICommand` to `INotification` mapping from the Controller.
+
+- parameter notificationName: the name of the `INotification` to remove the `ICommand` mapping for
+*/
 - (void)removeCommand:(NSString *)notificationName;
 
+/**
+Register an `IProxy` with the `Model` by name.
+
+- parameter proxy: the `IProxy` to be registered with the `Model`.
+*/
 - (void)registerProxy:(id<IProxy>)proxy;
+
+/**
+Retrieve a `IProxy` from the `Model` by name.
+
+- parameter proxyName: the name of the `IProxy` instance to be retrieved.
+- returns: the `IProxy` previously regisetered by `proxyName` with the `Model`.
+*/
 - (nullable id<IProxy>)retrieveProxy:(NSString *)proxyName;
+
+/**
+Check if a Proxy is registered
+
+- parameter proxyName:
+- returns: whether a Proxy is currently registered with the given `proxyName`.
+*/
 - (BOOL)hasProxy:(NSString *)proxyName;
+
+/**
+Remove an `IProxy` instance from the `Model` by name.
+
+- parameter proxyName: the `IProxy` to remove from the `Model`.
+- returns: the `IProxy` that was removed from the `Model`
+*/
 - (nullable id<IProxy>)removeProxy:(NSString *)proxyName;
 
+/**
+Register an `IMediator` instance with the `View`.
+
+- parameter mediator: a reference to the `IMediator` instance
+*/
 - (void)registerMediator:(id<IMediator>)mediator;
+
+/**
+Retrieve an `IMediator` instance from the `View`.
+
+- parameter mediatorName: the name of the `IMediator` instance to retrievve
+- returns: the `IMediator` previously registered with the given `mediatorName`.
+*/
 - (nullable id<IMediator>)retrieveMediator:(NSString *)mediatorName;
+
+/**
+Check if a Mediator is registered or not
+
+- parameter mediatorName:
+- returns: whether a Mediator is registered with the given `mediatorName`.
+*/
 - (BOOL)hasMediator:(NSString *)mediatorName;
+
+/**
+Remove a `IMediator` instance from the `View`.
+
+- parameter mediatorName: name of the `IMediator` instance to be removed.
+- returns: the `IMediator` instance previously registered with the given `mediatorName`.
+*/
 - (nullable id<IMediator>)removeMediator:(NSString *)mediatorName;
 
+/**
+Notify `Observer`s.
+
+This method is left public mostly for backward
+compatibility, and to allow you to send custom
+notification classes using the facade.
+
+Usually you should just call sendNotification
+and pass the parameters, never having to
+construct the notification yourself.
+
+- parameter notification: the `INotification` to have the `View` notify `Observers` of.
+*/
 - (void)notifyObservers:(id<INotification>)notification;
 
 @end

--- a/PureMVC/headers/IMediator.h
+++ b/PureMVC/headers/IMediator.h
@@ -15,17 +15,59 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Mediator.
+
+In PureMVC, `IMediator` implementors assume these responsibilities:
+
+* Implement a common method which returns a list of all `INotification`s the `IMediator` has interest in.
+* Implement a notification callback method.
+* Implement methods that are called when the IMediator is registered or removed from the View.
+
+Additionally, `IMediator`s typically:
+
+* Act as an intermediary between one or more view components such as text boxes or list controls, maintaining references and coordinating their behavior.
+* In Flash-based apps, this is often the place where event listeners are added to view components, and their handlers implemented.
+* Respond to and generate `INotifications`, interacting with of the rest of the PureMVC app.
+
+When an `IMediator` is registered with the `IView`,
+the `IView` will call the `IMediator`'s
+`listNotificationInterests` method. The `IMediator` will
+return an `Array` of `INotification` names which
+it wishes to be notified about.
+
+The `IView` will then create an `Observer` object
+encapsulating that `IMediator`'s (`handleNotification`) method
+and register it as an Observer for each `INotification` name returned by
+`listNotificationInterests`.
+
+`@see org.puremvc.swift.multicore.interfaces.INotification INotification`
+*/
 @protocol IMediator <INotifier>
 
+/// Get the `IMediator` instance name
 @property (nonatomic, copy, readonly) NSString *name;
+/// Get or set the `IMediator`'s view component.
 @property (nonatomic, strong, nullable) id view;
 
+/// Called by the View when the Mediator is registered
 - (void)onRegister;
 
+/// Called by the View when the Mediator is removed
 - (void)onRemove;
 
+/**
+List `INotification` interests.
+
+- returns: an `Array` of the `INotification` names this `IMediator` has an interest in.
+*/
 - (NSArray<NSString *> *)listNotificationInterests;
 
+/**
+Handle an `INotification`.
+
+- parameter notification: the `INotification` to be handled
+*/
 - (void)handleNotification:(id<INotification>)notification;
 
 @end

--- a/PureMVC/headers/IModel.h
+++ b/PureMVC/headers/IModel.h
@@ -14,14 +14,48 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Model.
+
+In PureMVC, `IModel` implementors provide
+access to `IProxy` objects by named lookup.
+
+An `IModel` assumes these responsibilities:
+
+* Maintain a cache of `IProxy` instances
+* Provide methods for registering, retrieving, and removing `IProxy` instances
+*/
 @protocol IModel
 
+/**
+Register an `IProxy` instance with the `Model`.
+
+- parameter proxy: an object reference to be held by the `Model`.
+*/
 - (void)registerProxy:(id<IProxy>)proxy;
 
+/**
+Retrieve an `IProxy` instance from the Model.
+
+- parameter proxyName:
+- returns: the `IProxy` instance previously registered with the given `proxyName`.
+*/
 - (nullable id<IProxy>)retrieveProxy:(NSString *)proxyName;
 
+/**
+Check if a Proxy is registered
+
+- parameter proxyName:
+- returns: whether a Proxy is currently registered with the given `proxyName`.
+*/
 - (BOOL)hasProxy:(NSString *)proxyName;
 
+/**
+Remove an `IProxy` instance from the Model.
+
+- parameter proxyName: name of the `IProxy` instance to be removed.
+- returns: the `IProxy` that was removed from the `Model`
+*/
 - (nullable id<IProxy>)removeProxy:(NSString *)proxyName;
 
 @end

--- a/PureMVC/headers/INotification.h
+++ b/PureMVC/headers/INotification.h
@@ -13,12 +13,50 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Notification.
+
+PureMVC does not rely upon underlying event models such
+as the one provided with Flash, and ActionScript 3 does
+not have an inherent event model.
+
+The Observer Pattern as implemented within PureMVC exists
+to support event-driven communication between the
+application and the actors of the MVC triad.
+
+Notifications are not meant to be a replacement for Events
+in Flex/Flash/AIR. Generally, `IMediator` implementors
+place event listeners on their view components, which they
+then handle in the usual way. This may lead to the broadcast of `Notification`s to
+trigger `ICommand`s or to communicate with other `IMediators`. `IProxy` and `ICommand`
+instances communicate with each other and `IMediator`s
+by broadcasting `INotification`s.
+
+A key difference between Flash `Event`s and PureMVC
+`Notification`s is that `Event`s follow the
+'Chain of Responsibility' pattern, 'bubbling' up the display hierarchy
+until some parent component handles the `Event`, while
+PureMVC `Notification`s follow a 'Publish/Subscribe'
+pattern. PureMVC classes need not be related to each other in a
+parent/child relationship in order to communicate with one another
+using `Notification`s.
+
+`@see org.puremvc.swift.multicore.interfaces.IView IView`
+
+`@see org.puremvc.swift.multicore.interfaces.IObserver IObserver`
+*/
 @protocol INotification
 
+/// Get the name of the `INotification` instance.
 @property (nonatomic, copy, readonly) NSString *name;
+
+/// Get or set the body of the `INotification` instance
 @property (nonatomic, strong, nullable) id body;
+
+/// Get or set the type of the `INotification` instance
 @property (nonatomic, copy, nullable) NSString *type;
 
+/// Get the string representation of the `INotification` instance
 - (NSString *)description;
 
 @end

--- a/PureMVC/headers/INotifier.h
+++ b/PureMVC/headers/INotifier.h
@@ -13,12 +13,53 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Notifier.
+
+`MacroCommand, Command, Mediator` and `Proxy`
+all have a need to send `Notifications`.
+
+The `INotifier` interface provides a common method called
+`sendNotification` that relieves implementation code of
+the necessity to actually construct `Notifications`.
+
+The `Notifier` class, which all of the above mentioned classes
+extend, also provides an initialized reference to the `Facade`
+Singleton, which is required for the convienience method
+for sending `Notifications`, but also eases implementation as these
+classes have frequent `Facade` interactions and usually require
+access to the facade anyway.
+
+`@see org.puremvc.swift.multicore.interfaces.IFacade IFacade`
+
+`@see org.puremvc.swift.multicore.interfaces.INotification INotification`
+*/
 @protocol IFacade;
 
 @protocol INotifier
 
+/**
+Initialize this INotifier instance.
+
+This is how a Notifier gets its multitonKey.
+Calls to sendNotification or to access the
+facade will fail until after this method
+has been called.
+
+- parameter key: the multitonKey for this INotifier to use
+*/
 - (void)initializeNotifier:(NSString *)key;
 
+/**
+Send a `INotification`.
+
+Convenience method to prevent having to construct new
+notification instances in our implementation code.
+
+- parameter notificationName: the name of the notification to send
+- parameter body: the body of the notification
+- parameter type: the type of the notification
+*/
 - (void)sendNotification:(NSString *)notificationName body:(nullable id)body type:(nullable NSString *)type;
 - (void)sendNotification:(NSString *)notificationName;
 - (void)sendNotification:(NSString *)notificationName body:(id)body;

--- a/PureMVC/headers/IObserver.h
+++ b/PureMVC/headers/IObserver.h
@@ -14,12 +14,67 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Observer.
+
+In PureMVC, `IObserver` implementors assume these responsibilities:
+
+* Encapsulate the notification (callback) method of the interested object.
+* Encapsulate the notification context (self) of the interested object.
+* Provide methods for setting the interested object' notification method and context.
+* Provide a method for notifying the interested object.
+
+PureMVC does not rely upon underlying event
+models such as the one provided with Flash,
+and ActionScript 3 does not have an inherent
+event model.
+
+The Observer Pattern as implemented within
+PureMVC exists to support event driven communication
+between the application and the actors of the
+MVC triad.
+
+An Observer is an object that encapsulates information
+about an interested object with a notification method that
+should be called when an `INotification` is broadcast. The Observer then
+acts as a proxy for notifying the interested object.
+
+Observers can receive `Notification`s by having their
+`notifyObserver` method invoked, passing
+in an object implementing the `INotification` interface, such
+as a subclass of `Notification`.
+
+`@see org.puremvc.swift.multicore.interfaces.IView IView`
+
+`@see org.puremvc.swift.multicore.interfaces.INotification INotification`
+*/
 @protocol IObserver
 
+/**
+Set the notification method.
+
+The notification method should take one parameter of type `INotification`
+
+- parameter notifyMethod: the notification (callback) method of the interested object
+*/
 @property (nonatomic) SEL notify;
+
+/// Get or set the notification context (self) of the interested object.
 @property (nonatomic, weak) id context;
 
+/**
+Notify the interested object.
+
+- parameter notification: the `INotification` to pass to the interested object's notification method
+*/
 - (void)notifyObserver:(id<INotification>)notification;
+
+/**
+Compare the given object to the notificaiton context object.
+
+- parameter object: the object to compare.
+- returns: boolean indicating if the notification context and the object are the same.
+*/
 - (BOOL)compareNotifyContext:(id)object;
 
 @end

--- a/PureMVC/headers/IProxy.h
+++ b/PureMVC/headers/IProxy.h
@@ -14,13 +14,34 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC Proxy.
+
+In PureMVC, `IProxy` implementors assume these responsibilities:
+
+* Implement a common method which returns the name of the Proxy.
+* Provide methods for setting and getting the data object.
+
+Additionally, `IProxy`s typically:
+
+* Maintain references to one or more pieces of model data.
+* Provide methods for manipulating that data.
+* Generate `INotifications` when their model data changes.
+* Expose their name as a `public static const` called `NAME`, if they are not instantiated multiple times.
+* Encapsulate interaction with local or remote services used to fetch and persist model data.
+*/
 @protocol IProxy <INotifier>
 
+/// Get the Proxy name
 @property (nonatomic, copy, readonly) NSString *name;
+
+/// Get or set the data object
 @property (nonatomic, strong, nullable) id data;
 
+/// Called by the Model when the Proxy is registered
 - (void)onRegister;
 
+/// Called by the Model when the Proxy is removed
 - (void)onRemove;
 
 @end

--- a/PureMVC/headers/IView.h
+++ b/PureMVC/headers/IView.h
@@ -15,20 +15,95 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+The interface definition for a PureMVC View.
+
+In PureMVC, `IView` implementors assume these responsibilities:
+
+In PureMVC, the `View` class assumes these responsibilities:
+
+* Maintain a cache of `IMediator` instances.
+* Provide methods for registering, retrieving, and removing `IMediators`.
+* Managing the observer lists for each `INotification` in the application.
+* Providing a method for attaching `IObservers` to an `INotification`'s observer list.
+* Providing a method for broadcasting an `INotification`.
+* Notifying the `IObservers` of a given `INotification` when it broadcast.
+
+`@see org.puremvc.swift.multicore.interfaces.IMediator IMediator`
+
+`@see org.puremvc.swift.multicore.interfaces.IObserver IObserver`
+
+`@see org.puremvc.swift.multicore.interfaces.INotification INotification`
+*/
 @protocol IView
 
+/**
+Register an `IObserver` to be notified
+of `INotifications` with a given name.
+
+- parameter notificationName: the name of the `INotifications` to notify this `IObserver` of
+- parameter observer: the `IObserver` to register
+*/
 - (void)registerObserver:(NSString *)notificationName observer:(id<IObserver>)observer;
 
+/**
+Notify the `IObservers` for a particular `INotification`.
+
+All previously attached `IObservers` for this `INotification`'s
+list are notified and are passed a reference to the `INotification` in
+the order in which they were registered.
+
+- parameter notification: the `INotification` to notify `IObservers` of.
+*/
 - (void)notifyObservers:(id<INotification>)notification;
 
+/**
+Remove a group of observers from the observer list for a given Notification name.
+
+- parameter notificationName: which observer list to remove from
+- parameter notifyContext: removed the observers with this object as their notifyContext
+*/
 - (void)removeObserver:(NSString *)notificationName context:(id)context;
 
+/**
+Register an `IMediator` instance with the `View`.
+
+Registers the `IMediator` so that it can be retrieved by name,
+and further interrogates the `IMediator` for its
+`INotification` interests.
+
+If the `IMediator` returns any `INotification`
+names to be notified about, an `Observer` is created encapsulating
+the `IMediator` instance's `handleNotification` method
+and registering it as an `Observer` for all `INotifications` the
+`IMediator` is interested in.
+
+- parameter mediator: a reference to the `IMediator` instance
+*/
 - (void)registerMediator:(id<IMediator>)mediator;
 
+/**
+Retrieve an `IMediator` from the `View`.
+
+- parameter mediatorName: the name of the `IMediator` instance to retrieve.
+- returns: the `IMediator` instance previously registered with the given `mediatorName`.
+*/
 - (nullable id<IMediator>)retrieveMediator:(NSString *)mediatorName;
 
+/**
+Check if a Mediator is registered or not
+
+- parameter mediatorName:
+- returns: whether a Mediator is registered with the given `mediatorName`.
+*/
 - (BOOL)hasMediator:(NSString *)mediatorName;
 
+/**
+Remove an `IMediator` from the `View`.
+
+- parameter mediatorName: name of the `IMediator` instance to be removed.
+- returns: the `IMediator` that was removed from the `View`
+*/
 - (nullable id<IMediator>)removeMediator:(NSString *)mediatorName;
 
 @end

--- a/PureMVC/headers/Model.h
+++ b/PureMVC/headers/Model.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (void) removeModel:(NSString *)key;
 + (instancetype) withKey:(NSString *)key;
 
+/**
+ Initialize the `Model` instance.
+ */
 - (instancetype) initWithKey:(NSString *)key;
 
 @end

--- a/PureMVC/headers/View.h
+++ b/PureMVC/headers/View.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)removeView:(NSString *)key;
 + (instancetype) withKey:(NSString *)key;
 
+/**
+ Initialize the  `View` instance.
+ */
 - (instancetype) initWithKey:(NSString *)key;
 
 @end

--- a/PureMVC/patterns/command/MacroCommand.m
+++ b/PureMVC/patterns/command/MacroCommand.m
@@ -17,12 +17,47 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+A base `ICommand` implementation that executes other `ICommand`s.
+
+A `MacroCommand` maintains an list of
+`ICommand` Class references called *SubCommands*.
+
+When `execute` is called, the `MacroCommand`
+retrieves `ICommands` by executing closures and then calls
+`execute` on each of its *SubCommands* turn.
+Each *SubCommand* will be passed a reference to the original
+`INotification` that was passed to the `MacroCommand`'s
+`execute` method.
+
+Unlike `SimpleCommand`, your subclass
+should not override `execute`, but instead, should
+override the `initializeMacroCommand` method,
+calling `addSubCommand` once for each *SubCommand*
+to be executed.
+
+`@see org.puremvc.swift.multicore.core.Controller Controller`
+
+`@see org.puremvc.swift.multicore.patterns.observer.Notification Notification`
+
+`@see org.puremvc.swift.multicore.patterns.command.SimpleCommand SimpleCommand`
+*/
 @implementation MacroCommand
 
 + (instancetype)command {
     return [[self alloc] init];
 }
 
+/**
+Constructor.
+
+You should not need to define a constructor,
+instead, override the `initializeMacroCommand`
+method.
+
+If your subclass does define a constructor, be
+sure to call `super()`.
+*/
 - (instancetype)init {
     if (self = [super init]) {
         _subCommands = [NSMutableArray array];
@@ -31,14 +66,48 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+/**
+Initialize the `MacroCommand`.
+
+In your subclass, override this method to
+initialize the `MacroCommand`'s *SubCommand*
+list with closure references like
+this:
+
+    // Initialize MyMacroCommand
+    public func addSubCommand(closure: () -> ICommand) {
+        addSubCommand( { FirstCommand() } );
+        addSubCommand( { SecondCommand() } );
+        addSubCommand { ThirdCommand() }; // or by using a trailing closure
+    }
+
+Note that *SubCommands* may be any closure returning `ICommand`
+implementor, `MacroCommands` or `SimpleCommands` are both acceptable.
+*/
 - (void)initializeMacroCommand {
     
 }
 
+/**
+Add a *SubCommand*.
+
+The *SubCommands* will be called in First In/First Out (FIFO)
+order.
+
+- parameter factory: reference that returns `ICommand`.
+*/
 - (void)addSubCommand:(id<ICommand> (^)(void))factory {
     [self.subCommands addObject:factory];
 }
 
+/**
+Execute this `MacroCommand`'s *SubCommands*.
+
+The *SubCommands* will be called in First In/First Out (FIFO)
+order.
+
+- parameter notification: the `INotification` object to be passsed to each *SubCommand*.
+*/
 - (void)execute:(id<INotification>)notification {
     while (self.subCommands.count > 0) {
         id<ICommand> (^factory)(void) = self.subCommands[0];

--- a/PureMVC/patterns/command/SimpleCommand.m
+++ b/PureMVC/patterns/command/SimpleCommand.m
@@ -12,12 +12,34 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A base `ICommand` implementation.
+
+Your subclass should override the `execute`
+method where your business logic will handle the `INotification`.
+
+`@see org.puremvc.swift.multicore.core.Controller Controller`
+
+`@see org.puremvc.swift.multicore.patterns.observer.Notification Notification`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommand MacroCommand`
+*/
 @implementation SimpleCommand
 
 + (instancetype)command {
     return [[self alloc] init];
 }
 
+/**
+Fulfill the use-case initiated by the given `INotification`.
+
+In the Command Pattern, an application use-case typically
+begins with some user action, which results in an `INotification` being broadcast, which
+is handled by business logic in the `execute` method of an
+`ICommand`.
+
+- parameter notification: the `INotification` to handle.
+*/
 - (void)execute:(id<INotification>)notification {
     
 }

--- a/PureMVC/patterns/facade/Facade.m
+++ b/PureMVC/patterns/facade/Facade.m
@@ -36,8 +36,24 @@ static void initialize(void) {
     instanceMap = [NSMutableDictionary dictionary];
 }
 
+/**
+A base Multiton `IFacade` implementation.
+
+`@see org.puremvc.swift.multicore.core.Model Model`
+
+`@see org.puremvc.swift.multicore.core.View View`
+
+`@see org.puremvc.swift.multicore.core.Controller Controller`
+*/
 @implementation Facade
 
+/**
+Facade Multiton Factory method
+
+- parameter key: multitonKey
+- parameter factory: reference that returns `IFacade`
+- returns: the Multiton instance of the `IFacade`
+*/
 + (id<IFacade>)getInstance:(NSString *)key factory:(id<IFacade> (^)(NSString *key))factory {
     @synchronized (instanceMap) {
         if (instanceMap[key] == nil) {
@@ -47,12 +63,26 @@ static void initialize(void) {
     }
 }
 
+/**
+Check if a Core is registered or not
+
+- parameter key: the multiton key for the Core in question
+- returns: whether a Core is registered with the given `key`.
+*/
 + (BOOL)hasCore:(NSString *)key {
     @synchronized (instanceMap) {
         return instanceMap[key] != nil;
     }
 }
 
+/**
+Remove a Core.
+
+Remove the Model, View, Controller and Facade
+instances for the given key.
+
+- parameter key: multitonKey of the Core to remove
+*/
 + (void)removeCore:(NSString *)key {
     @synchronized (instanceMap) {
         [instanceMap removeObjectForKey:key];
@@ -63,6 +93,18 @@ static void initialize(void) {
     return [[Facade alloc] initWithKey:key];
 }
 
+/**
+Constructor.
+
+This `IFacade` implementation is a Multiton,
+so you should not call the constructor
+directly, but instead call the static Factory method,
+passing the unique key for this instance and the factory closure
+that returns the `IFacade` implementation.
+`Facade.getInstance( multitonKey ) { Facade(key: multitonKey) }`
+
+@throws Error Error if instance for this Multiton key has already been constructed
+*/
 - (instancetype)initWithKey:(NSString *)key {
     if (instanceMap[key] != nil) {
         [NSException raise:@"FacadeAlreadyExistsException" format:@"A Facade instance already exists for key '%@'.", key];
@@ -75,76 +117,231 @@ static void initialize(void) {
     return self;
 }
 
+/**
+Initialize the Multiton `Facade` instance.
+
+Called automatically by the constructor. Override in your
+subclass to do any subclass specific initializations. Be
+sure to call `super.initializeFacade()`, though.
+*/
 - (void)initializeFacade {
     [self initializeModel];
     [self initializeController];
     [self initializeView];
 }
 
+/**
+Initialize the `Controller`.
+
+Called by the `initializeFacade` method.
+Override this method in your subclass of `Facade`
+if one or both of the following are true:
+
+* You wish to initialize a different `IController`.
+* You have `Commands` to register with the `Controller` at startup.`.
+
+If you don't want to initialize a different `IController`,
+call `super.initializeController()` at the beginning of your
+method, then register `Command`s.
+*/
 - (void)initializeController {
     self.controller = [Controller getInstance:self.multitonKey factory:^(NSString *key){ return [Controller withKey:key]; }];
 }
 
+/**
+Initialize the `Model`.
+
+Called by the `initializeFacade` method.
+Override this method in your subclass of `Facade`
+if one or both of the following are true:
+
+* You wish to initialize a different `IModel`.
+* You have `Proxy`s to register with the Model that do not retrieve a reference to the Facade at construction time.`
+
+If you don't want to initialize a different `IModel`,
+call `super.initializeModel()` at the beginning of your
+method, then register `Proxy`s.
+
+Note: This method is *rarely* overridden; in practice you are more
+likely to use a `Command` to create and register `Proxy`s
+with the `Model`, since `Proxy`s with mutable data will likely
+need to send `INotification`s and thus will likely want to fetch a reference to
+the `Facade` during their construction.
+*/
 - (void)initializeModel {
     self.model = [Model getInstance:self.multitonKey factory:^(NSString *key) { return [Model withKey:key]; }];
 }
 
+/**
+Initialize the `View`.
+
+Called by the `initializeFacade` method.
+Override this method in your subclass of `Facade`
+if one or both of the following are true:
+
+* You wish to initialize a different `IView`.
+* You have `Observers` to register with the `View`
+
+If you don't want to initialize a different `IView`,
+call `super.initializeView()` at the beginning of your
+method, then register `IMediator` instances.
+
+Note: This method is *rarely* overridden; in practice you are more
+likely to use a `Command` to create and register `Mediator`s
+with the `View`, since `IMediator` instances will need to send
+`INotification`s and thus will likely want to fetch a reference
+to the `Facade` during their construction.
+*/
 - (void)initializeView {
     self.view = [View getInstance:self.multitonKey factory:^(NSString *key) { return [View withKey:key]; }];
 }
 
+/**
+Register an `ICommand` with the `Controller` by Notification name.
+
+- parameter notificationName: the name of the `INotification` to associate the `ICommand` with
+- parameter factory: reference that returns `ICommand`
+*/
 - (void)registerCommand:(NSString *)notificationName factory:(id<ICommand> (^)(void))factory {
     [self.controller registerCommand:notificationName factory:factory];
 }
 
+/**
+Check if a Command is registered for a given Notification
+
+- parameter notificationName:
+- returns: whether a Command is currently registered for the given `notificationName`.
+*/
 - (BOOL)hasCommand:(NSString *)notificationName {
     return [self.controller hasCommand:notificationName];
 }
 
+/**
+Remove a previously registered `ICommand` to `INotification` mapping from the Controller.
+
+- parameter notificationName: the name of the `INotification` to remove the `ICommand` mapping for
+*/
 - (void)removeCommand:(NSString *)notificationName {
     [self.controller removeCommand:notificationName];
 }
 
+/**
+Register an `IProxy` with the `Model` by name.
+
+- parameter proxy: the `IProxy` instance to be registered with the `Model`.
+*/
 - (void)registerProxy:(id<IProxy>)proxy {
     [self.model registerProxy:proxy];
 }
 
+/**
+Retrieve an `IProxy` from the `Model` by name.
+
+- parameter proxyName: the name of the proxy to be retrieved.
+- returns: the `IProxy` instance previously registered with the given `proxyName`.
+*/
 - (nullable id<IProxy>)retrieveProxy:(NSString *)proxyName {
     return [self.model retrieveProxy:proxyName];
 }
 
+/**
+Check if a Proxy is registered
+
+- parameter proxyName:
+- returns: whether a Proxy is currently registered with the given `proxyName`.
+*/
 - (BOOL)hasProxy:(NSString *)proxyName {
     return [self.model hasProxy:proxyName];
 }
 
+/**
+Remove an `IProxy` from the `Model` by name.
+
+- parameter proxyName: the `IProxy` to remove from the `Model`.
+- returns: the `IProxy` that was removed from the `Model`
+*/
 - (nullable id<IProxy>)removeProxy:(NSString *)proxyName {
     return [self.model removeProxy:proxyName];
 }
 
+/**
+Register a `IMediator` with the `View`.
+
+- parameter mediator: a reference to the `IMediator`
+*/
 - (void)registerMediator:(id<IMediator>)mediator {
     [self.view registerMediator:mediator];
 }
 
+/**
+Retrieve an `IMediator` from the `View`.
+
+- parameter mediatorName:
+- returns: the `IMediator` previously registered with the given `mediatorName`.
+*/
 - (nullable id<IMediator>)retrieveMediator:(NSString *)mediatorName {
     return [self.view retrieveMediator:mediatorName];
 }
 
+/**
+Check if a Mediator is registered or not
+
+- parameter mediatorName:
+- returns: whether a Mediator is registered with the given `mediatorName`.
+*/
 - (BOOL)hasMediator:(NSString *)mediatorName {
     return [self.view hasMediator:mediatorName];
 }
 
+/**
+Remove an `IMediator` from the `View`.
+
+- parameter mediatorName: name of the `IMediator` to be removed.
+- returns: the `IMediator` that was removed from the `View`
+*/
 - (nullable id<IMediator>)removeMediator:(NSString *)mediatorName {
     return [self.view removeMediator:mediatorName];
 }
 
+/**
+Notify `Observer`s.
+
+This method is left public mostly for backward
+compatibility, and to allow you to send custom
+notification classes using the facade.
+
+Usually you should just call sendNotification
+and pass the parameters, never having to
+construct the notification yourself.
+
+- parameter notification: the `INotification` to have the `View` notify `Observers` of.
+*/
 - (void)notifyObservers:(id<INotification>)notification {
     [self.view notifyObservers:notification];
 }
 
+/**
+Set the Multiton key for this facade instance.
+
+Not called directly, but instead from the
+constructor when getInstance is invoked.
+It is necessary to be public in order to
+implement INotifier.
+*/
 - (void)initializeNotifier:(NSString *)key {
     _multitonKey = [key copy];
 }
 
+/**
+Create and send an `INotification`.
+
+Keeps us from having to construct new notification
+instances in our implementation code.
+
+- parameter notificationName: the name of the notiification to send
+- parameter body: the body of the notification (
+- parameter type: the type of the notification
+*/
 - (void)sendNotification:(NSString *)notificationName body:(nullable id)body type:(nullable NSString *)type {
     [self notifyObservers:[Notification withName:notificationName body:body type:type]];
 }

--- a/PureMVC/patterns/mediator/Mediator.m
+++ b/PureMVC/patterns/mediator/Mediator.m
@@ -12,18 +12,32 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A base `IMediator` implementation.
+
+`@see org.puremvc.swift.multicore.core.View View`
+*/
 @implementation Mediator
 
+/**
+The name of the `Mediator`.
+
+Typically, a `Mediator` will be written to serve
+one specific control or group controls and so,
+will not have a need to be dynamically named.
+*/
 + (NSString *)NAME { return @"Mediator"; }
 
 + (instancetype)mediator {
     return [[self alloc] initWithName:[[self class] NAME] view:nil];
 }
 
+/// The mediator name
 + (instancetype)withName:(NSString *)name {
     return [[self alloc] initWithName:name view:nil];
 }
 
+/// The view component
 + (instancetype)withView:(id)view {
     return [[self alloc] initWithName:[[self class] NAME] view:view];
 }
@@ -32,6 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithName:name view:view];
 }
 
+/**
+Constructor.
+
+- parameter name: the mediator name
+- parameter viewComponent: viewComponent instance
+*/
 - (instancetype)initWithName:(nullable NSString *)name view:(nullable id)view {
     if (self = [super init]) {
         _name = (name == nil) ? [[self class] NAME] : [name copy];
@@ -40,18 +60,33 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+/// Called by the View when the Mediator is registered
 - (void)onRegister {
     
 }
 
+/// Called by the View when the Mediator is removed
 - (void)onRemove {
     
 }
 
+/**
+List the `INotification` names this
+`Mediator` is interested in being notified of.
+
+- returns: Array the list of `INotification` names
+*/
 - (NSArray<NSString *> *)listNotificationInterests {
     return @[];
 }
 
+/**
+Handle `INotification`s.
+
+Typically this will be handled in a switch statement,
+with one 'case' entry per `INotification`
+the `Mediator` is interested in.
+*/
 - (void)handleNotification:(id<INotification>)notification {
     
 }

--- a/PureMVC/patterns/observer/Notification.m
+++ b/PureMVC/patterns/observer/Notification.m
@@ -11,20 +11,61 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A base `INotification` implementation.
+
+PureMVC does not rely upon underlying event models such
+as the one provided with Flash, and ActionScript 3 does
+not have an inherent event model.
+
+The Observer Pattern as implemented within PureMVC exists
+to support event-driven communication between the
+application and the actors of the MVC triad.
+
+Notifications are not meant to be a replacement for Events
+in Flex/Flash/Apollo. Generally, `IMediator` implementors
+place event listeners on their view components, which they
+then handle in the usual way. This may lead to the broadcast of `Notification`s to
+trigger `ICommand`s or to communicate with other `IMediators`. `IProxy` and `ICommand`
+instances communicate with each other and `IMediator`s
+by broadcasting `INotification`s.
+
+A key difference between Flash `Event`s and PureMVC
+`Notification`s is that `Event`s follow the
+'Chain of Responsibility' pattern, 'bubbling' up the display hierarchy
+until some parent component handles the `Event`, while
+PureMVC `Notification`s follow a 'Publish/Subscribe'
+pattern. PureMVC classes need not be related to each other in a
+parent/child relationship in order to communicate with one another
+using `Notification`s.
+
+`@see org.puremvc.swift.multicore.patterns.observer.Observer Observer`
+*
+*/
 @implementation Notification
 
+/// The name of the notification instance
 + (instancetype)withName:(NSString *)name {
     return [[self alloc] initWithName:name body:nil type:nil];
 }
 
+/// The body of the notification instance
 + (instancetype)withName:(NSString *)name body:(id)body {
     return [[self alloc] initWithName:name body:body type:nil];
 }
 
+/// The type of the notification instance
 + (instancetype)withName:(NSString *)name body:(id)body type:(NSString *)type {
     return [[self alloc] initWithName:name body:body type:type];
 }
 
+/**
+Constructor.
+
+- parameter name: name of the `Notification` instance. (required)
+- parameter body: the `Notification` body. (optional)
+- parameter type: the type of the `Notification` (optional)
+*/
 - (instancetype)initWithName:(NSString *)name body:(nullable id)body type:(nullable NSString *)type {
     if (self = [super init]) {
         _name = name;
@@ -34,6 +75,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+/**
+Get the string representation of the `Notification` instance.
+
+- returns: the string representation of the `Notification` instance.
+*/
 - (NSString *)description {
     return [NSString stringWithFormat:@"Notification Name: %@\nBody: %@\nType: %@", _name, _body, _type];
 }

--- a/PureMVC/patterns/observer/Notifier.m
+++ b/PureMVC/patterns/observer/Notifier.m
@@ -19,19 +19,85 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+A Base `INotifier` implementation.
+
+`MacroCommand, Command, Mediator` and `Proxy`
+all have a need to send `Notifications`.
+
+The `INotifier` interface provides a common method called
+`sendNotification` that relieves implementation code of
+the necessity to actually construct `Notifications`.
+
+The `Notifier` class, which all of the above mentioned classes
+extend, provides an initialized reference to the `Facade`
+Multiton, which is required for the convienience method
+for sending `Notifications`, but also eases implementation as these
+classes have frequent `Facade` interactions and usually require
+access to the facade anyway.
+
+NOTE: In the MultiCore version of the framework, there is one caveat to
+notifiers, they cannot send notifications or reach the facade until they
+have a valid multitonKey.
+
+The multitonKey is set:
+* on a Command when it is executed by the Controller
+* on a Mediator is registered with the View
+* on a Proxy is registered with the Model.
+
+`@see org.puremvc.swift.multicore.patterns.proxy.Proxy Proxy`
+
+`@see org.puremvc.swift.multicore.patterns.facade.Facade Facade`
+
+`@see org.puremvc.swift.multicore.patterns.mediator.Mediator Mediator`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommand MacroCommand`
+
+`@see org.puremvc.swift.multicore.patterns.command.SimpleCommand SimpleCommand`
+*/
 @implementation Notifier
 
+/// Reference to the Facade Multiton
 - (nullable id<IFacade>)facade {
     if (self.multitonKey == nil) {
+        // Message constant
         [NSException raise:@"MultitonException" format:@"multitonKey for this Notifier not yet initialized!"];
     }
+    // returns instance mapped to multitonKey if it exists otherwise defaults to Facade
     return [Facade getInstance:self.multitonKey factory:^(NSString *key) { return [Facade withKey:key]; }];
 }
 
+/**
+Initialize this INotifier instance.
+
+This is how a Notifier gets its multitonKey.
+Calls to sendNotification or to access the
+facade will fail until after this method
+has been called.
+
+Mediators, Commands or Proxies may override
+this method in order to send notifications
+or access the Multiton Facade instance as
+soon as possible. They CANNOT access the facade
+in their constructors, since this method will not
+yet have been called.
+
+- parameter key: the multitonKey for this INotifier to use
+*/
 - (void)initializeNotifier:(NSString *)key {
     _multitonKey = key;
 }
 
+/**
+Create and send an `INotification`.
+
+Keeps us from having to construct new INotification
+instances in our implementation code.
+
+- parameter notificationName: the name of the notification to send
+- parameter body: the body of the notification (optional)
+- parameter type: the type of the notification (optional)
+*/
 - (void)sendNotification:(NSString *)notificationName body:(nullable id)body type:(nullable NSString *)type {
     [self sendNotification:notificationName body:body type:type];
 }

--- a/PureMVC/patterns/observer/Observer.m
+++ b/PureMVC/patterns/observer/Observer.m
@@ -11,12 +11,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A base `IObserver` implementation.
+
+An `Observer` is an object that encapsulates information
+about an interested object with a method that should
+be called when a particular `INotification` is broadcast.
+
+In PureMVC, the `Observer` class assumes these responsibilities:
+
+* Encapsulate the notification (callback) method of the interested object.
+* Encapsulate the notification context (this) of the interested object.
+* Provide methods for setting the notification method and context.
+* Provide a method for notifying the interested object.
+
+`@see org.puremvc.swift.multicore.core.View View`
+
+`@see org.puremvc.swift.multicore.patterns.observer.Notification Notification`
+*/
 @implementation Observer
 
 + (instancetype)withNotify:(nullable SEL)notify context:(nullable id)context {
     return [[self alloc] initWithNotify:notify context:context];
 }
 
+/**
+Constructor.
+
+The notification method on the interested object should take
+one parameter of type `INotification`
+
+- parameter notifyMethod: the notification method of the interested object
+- parameter notifyContext: the notification context of the interested object
+*/
 - (instancetype)initWithNotify:(nullable SEL)notify context:(nullable id)context {
     if (self = [super init]) {
         _notify = notify;
@@ -25,6 +52,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+/**
+Notify the interested object.
+
+- parameter notification: the `INotification` to pass to the interested object's notification method.
+*/
 - (void)notifyObserver:(id<INotification>)notification {
     if (self.notify && [self.context respondsToSelector:self.notify]) {
         // Suppress "performSelector may cause leak" warning
@@ -35,6 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+/**
+Compare an object to the notification context.
+
+- parameter object: the object to compare
+- returns: boolean indicating if the object and the notification context are the same
+*/
 - (BOOL)compareNotifyContext:(id)object {
     return object == self.context;
 }

--- a/PureMVC/patterns/proxy/Proxy.m
+++ b/PureMVC/patterns/proxy/Proxy.m
@@ -11,18 +11,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A base `IProxy` implementation.
+
+In PureMVC, `Proxy` classes are used to manage parts of the
+application's data model.
+
+A `Proxy` might simply manage a reference to a local data object,
+in which case interacting with it might involve setting and
+getting of its data in synchronous fashion.
+
+`Proxy` classes are also used to encapsulate the application's
+interaction with remote services to save or retrieve data, in which case,
+we adopt an asyncronous idiom; setting data (or calling a method) on the
+`Proxy` and listening for a `Notification` to be sent
+when the `Proxy` has retrieved the data from the service.
+
+`@see org.puremvc.swift.multicore.core.Model Model`
+*/
 @implementation Proxy
 
+/// Default proxy name
 + (NSString *)NAME { return @"Proxy"; }
 
 + (instancetype)proxy {
     return [[self alloc] initWithName:[[self class] NAME] data: nil];
 }
 
+/// The proxy name
 + (instancetype)withName:(NSString *)name {
     return [[self alloc] initWithName:name data:nil];
 }
 
+/// The data object
 + (instancetype)withData:(id)data {
     return [[self alloc] initWithName:[[self class] NAME] data:nil];
 }
@@ -31,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [[self alloc] initWithName:name data:data];
 }
 
+/// Constructor
 - (instancetype)initWithName:(nullable NSString *)name data:(nullable id)data {
     if (self = [super init]) {
         _name = (name == nil) ? [[self class] NAME] : [name copy];
@@ -39,10 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+/// Called by the Model when the Proxy is registered
 - (void)onRegister {
     
 }
 
+/// Called by the Model when the Proxy is removed
 - (void)onRemove {
     
 }

--- a/PureMVCTests/core/ControllerTest.m
+++ b/PureMVCTests/core/ControllerTest.m
@@ -25,71 +25,140 @@
 
 @implementation ControllerTest
 
+/**
+Tests the Controller Multiton Factory Method
+*/
 - (void)testGetInstance {
     id<IController> controller = [Controller getInstance:@"ControllerTestKey1" factory:^(NSString *key) { return [Controller withKey:key]; } ];
     
+    // test assertions
     XCTAssertNotNil(controller, @"Expecting instance not nil");
+    // Test Factory Method
     XCTAssertTrue([(id)controller conformsToProtocol:@protocol(IController)], @"Expecting instance implements IController");
 }
 
+/**
+Tests Command registration and execution.
+
+This test gets a Multiton Controller instance
+and registers the ControllerTestCommand class
+to handle 'ControllerTest' Notifications.
+
+It then constructs such a Notification and tells the
+Controller to execute the associated Command.
+Success is determined by evaluating a property
+on an object passed to the Command, which will
+be modified when the Command executes.
+*/
 - (void)testRegisterAndExecuteCommand {
+    // Create the controller, register the ControllerTestCommand to handle 'ControllerTest' notes
     id<IController> controller = [Controller getInstance:@"ControllerTestKey2" factory:^(NSString *key) { return [Controller withKey:key]; }];
     [controller registerCommand:@"ControllerTest" factory:^() { return [ControllerTestCommand command]; }];
     
+    // Create a 'ControllerTest' note
     ControllerTestVO *vo = [[ControllerTestVO alloc] initWithInput:12];
     id<INotification> notification = [Notification withName:@"ControllerTest" body:vo];
     
+    // Tell the controller to execute the Command associated with the note
+    // the ControllerTestCommand invoked will multiply the vo.input value
+    // by 2 and set the result on vo.result
     [controller executeCommand:notification];
     
+    // Test assertions
     XCTAssertTrue(vo.result == 24, @"Exepcting vo.result == 24");
 }
 
+/**
+Tests Command registration and removal.
+
+Tests that once a Command is registered and verified
+working, it can be removed from the Controller.
+*/
 - (void)testRegisterAndRemoveCommand {
+    // Create the controller, register the ControllerTestCommand to handle 'ControllerTest' notes
     id<IController> controller = [Controller getInstance:@"ControllerTestKey3" factory:^(NSString *key){ return [Controller withKey:key]; }];
     [controller registerCommand:@"ControllerRemoveTest" factory:^() { return [ControllerTestCommand command]; }];
     
+    // Create a 'ControllerTest' note
     ControllerTestVO *vo = [[ControllerTestVO alloc] initWithInput:12];
     id<INotification> notification = [Notification withName:@"ControllerRemoveTest" body:vo];
     
+    // Tell the controller to execute the Command associated with the note
+    // the ControllerTestCommand invoked will multiply the vo.input value
+    // by 2 and set the result on vo.result
     [controller executeCommand:notification];
     
+    // test assertions
     XCTAssertTrue(vo.result == 24, @"Expecting vo.result == 24");
     
+    // Reset result
     vo.result = 0;
     
+    // Remove the Command from the Controller
     [controller removeCommand:@"ControllerRemoveTest"];
     
+    // Tell the controller to execute the Command associated with the
+    // note. This time, it should not be registered, and our vo result
+    // will not change
     [controller executeCommand:notification];
     
+    // Test assertions
     XCTAssertTrue(vo.result == 0, @"Expecting vo.result == 0");
 }
 
+/**
+Test hasCommand method.
+*/
 - (void)testHasCommand {
+    // Register the ControllerTestCommand to handle 'hasCommandTest' notes
     id<IController> controller = [Controller getInstance:@"ControllerTestKey4" factory:^(NSString *key){ return [Controller withKey:key]; }];
     [controller registerCommand:@"hasCommandTest" factory:^() { return [ControllerTestCommand command]; }];
     
+    // Test that hasCommand returns true for hasCommandTest notifications
     XCTAssertTrue([controller hasCommand:@"hasCommandTest"] == YES, @"Expecing [controller hasCommand:@'hasCommandTest'] == YES");
     
+    // Remove the Command from the Controller
     [controller removeCommand:@"hasCommandTest"];
     
+    // Test that hasCommand returns false for hasCommandTest notifications
     XCTAssertTrue([controller hasCommand:@"hasCommandTest"] == NO, @"Expecing [controller hasCommand:@'hasCommandTest'] == NO");
 }
 
+/**
+Tests Removing and Reregistering a Command
+
+Tests that when a Command is re-registered that it isn't fired twice.
+This involves, minimally, registration with the controller but
+notification via the View, rather than direct execution of
+the Controller's executeCommand method as is done above in
+testRegisterAndRemove. The bug under test was fixed in AS3 Standard
+Version 2.0.2. If you run the unit tests with 2.0.1 this
+test will fail.
+*/
 - (void)testReregisterAndExecuteCommand {
+    // Fetch the controller, register the ControllerTestCommand2 to handle 'ControllerTest2' notes
     id<IController> controller = [Controller getInstance:@"ControllerTestKey5" factory:^(NSString *key) { return [Controller withKey:key]; }];
     
     [controller registerCommand:@"ControllerTest2" factory:^(){ return [ControllerTestCommand command]; }];
     
+    // Remove the Command from the Controller
     [controller removeCommand:@"ControllerTest2"];
     
+    // Re-register the Command with the Controller
     [controller registerCommand:@"ControllerTest2" factory:^(){ return [ControllerTestCommand command]; }];
     
+    // Create a 'ControllerTest2' note
     ControllerTestVO *vo = [[ControllerTestVO alloc] initWithInput:12];
     id<INotification> notification = [Notification withName:@"ControllerTest2" body:vo];
 
+    // Retrieve a reference to the View from the same core.
     id<IView> view = [View getInstance:@"ControllerTestKey5" factory:^(NSString *key) { return [View withKey:key]; }];
+    
+    // Send the Notification
     [view notifyObservers:notification];
     
+    // Test assertions
+    // If the command is executed once the value will be 24
     XCTAssertTrue(vo.result == 24, @"Expecting vo.result == 24");
 }
 

--- a/PureMVCTests/core/ControllerTestCommand2.h
+++ b/PureMVCTests/core/ControllerTestCommand2.h
@@ -14,6 +14,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A SimpleCommand subclass used by ControllerTest.
+
+`@see org.puremvc.as3.multicore.core.controller.ControllerTest ControllerTest`
+
+`@see org.puremvc.as3.multicore.core.controller.ControllerTestVO ControllerTestVO`
+*/
 @interface ControllerTestCommand2 : SimpleCommand
 
 @end

--- a/PureMVCTests/core/ControllerTestCommand2.m
+++ b/PureMVCTests/core/ControllerTestCommand2.m
@@ -13,10 +13,17 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation ControllerTestCommand2
+/**
+Fabricate a result by multiplying the input by 2 and adding to the existing result
 
+This tests accumulation effect that would show if the command were executed more than once.
+
+- parameter note: the note carrying the ControllerTestVO
+*/
 - (void)execute:(id<INotification>)notification {
     ControllerTestVO *vo = notification.body;
     
+    // Fabricate a result
     vo.result = vo.result + (2 * vo.input);
 }
 

--- a/PureMVCTests/core/ControllerTestVO.h
+++ b/PureMVCTests/core/ControllerTestVO.h
@@ -13,6 +13,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A utility class used by ControllerTest.
+
+`@see org.puremvc.swift.multicore.core.controller.ControllerTest ControllerTest`
+
+`@see org.puremvc.swift.multicore.core.controller.ControllerTestCommand ControllerTestCommand`
+*/
 @interface ControllerTestVO : NSObject
 
 @property (nonatomic, assign, readonly) int input;

--- a/PureMVCTests/core/ControllerTestVO.m
+++ b/PureMVCTests/core/ControllerTestVO.m
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ControllerTestVO
 
+/**
+Constructor.
+
+- parameter input: the number to be fed to the ControllerTestCommand
+*/
 - (instancetype)initWithInput:(int)input {
     if(self = [super init]) {
         _input = input;

--- a/PureMVCTests/core/ModelTest.m
+++ b/PureMVCTests/core/ModelTest.m
@@ -19,20 +19,35 @@
 
 @implementation ModelTest
 
+/**
+Tests the Model Multiton Factory Method
+*/
 - (void)testGetInstance {
+    // Test Factory Method
     id<IModel> model = [Model getInstance:@"ModelTestKey1" factory:^(NSString *key) { return [Model withKey:key]; }];
     // id<IModel> model = [Model getInstance:@"ModelTestKey1" factory:(id<IModel> (^)(NSString *))^(NSString *key) { return [Model withKey:key]; }];
     
+    // test assertions
     XCTAssertNotNil(model, @"Expecting instance not nil");
     XCTAssertTrue([(id)model conformsToProtocol:@protocol(IModel)], @"Expecting instance implements IModel");
 }
 
+/**
+Tests the proxy registration and retrieval methods.
+
+Tests `registerProxy` and `retrieveProxy` in the same test.
+These methods cannot currently be tested separately
+in any meaningful way other than to show that the
+methods do not throw exception when called.
+*/
 - (void)testRegisterAndRetrieveProxy {
+    // Register a proxy and retrieve it.
     id<IModel> model = [Model getInstance:@"ModelTestKey2" factory:^(NSString *key) { return [Model withKey:key]; }];
     [model registerProxy: [Proxy withName:@"colors" data:@[@"red", @"green", @"blue"]]];
     id<IProxy> proxy = [model retrieveProxy:@"colors"];
     NSArray *data = [proxy data];
     
+    // Test assertions
     XCTAssertNotNil(data, @"Expecting data not nil");
     XCTAssertTrue([data isKindOfClass:[NSArray class]], @"Expecting data type is NSArray");
     XCTAssertEqual([data count], 3, @"Expecting data.count == 3");
@@ -41,41 +56,67 @@
     XCTAssertEqualObjects(data[2], @"blue", @"Expecting data[2] == 'blue'");
 }
 
+/**
+Tests the proxy removal method.
+*/
 - (void)testRegisterAndRemoveProxy {
+    // Register a proxy, remove it, then try to retrieve it
     id<IModel> model = [Model getInstance:@"ModelTestKey3" factory:^(NSString *key) { return [Model withKey:key]; }];
     id<IProxy> proxy = [Proxy withName:@"sizes" data:@[@(7), @(13), @(21)]];
     [model registerProxy:proxy];
     
+    // Remove the proxy
     id<IProxy> removedProxy = [model removeProxy:@"sizes"];
     
+    // Assert that we removed the appropriate proxy
     XCTAssertEqualObjects(removedProxy.name, @"sizes", @"Expecting removedProxy.name == 'sizes'");
 
+    // Ensure that the proxy is no longer retrievable from the model
     proxy = [model retrieveProxy:@"sizes"];
+    
+    // Test assertions
     XCTAssertNil(proxy, @"Expecting proxy is nil");
 }
 
+/**
+Tests the hasProxy Method
+*/
 - (void)testHasProxy {
+    // Register a proxy
     id<IModel> model = [Model getInstance:@"ModelTestKey4" factory:^(NSString *key){ return [Model withKey:key]; }];
     id<IProxy> proxy = [Proxy withName:@"aces" data:@[@"clubs", @"spades", @"hearts", @"diamonds"]];
     [model registerProxy:proxy];
     
+    // Assert that the model.hasProxy method returns true
+    // for that proxy name
     XCTAssertTrue([model hasProxy:@"aces"], @"Expecting [model hasProxy('aces')]");
     
+    // Remove the proxy
     [model removeProxy:@"aces"];
     
+    // Assert that the model.hasProxy method returns false
+    // for that proxy name
     XCTAssertTrue([model hasProxy:@"aces"] == false, @"Expecting [model hasProxy('aces')] == false");
 }
 
+/**
+Tests that the Model calls the onRegister and onRemove methods
+*/
 - (void)testOnRegisterAndOnRemove {
+    // Get a Multiton View instance
     id<IModel> model = [Model getInstance:@"ModelTestKey5" factory:^(NSString *key){ return [Model withKey:key]; }];
     
+    // Create and register the test mediator
     id<IProxy> proxy = [ModelTestProxy proxy];
     [model registerProxy:proxy];
     
+    // Assert that onRegsiter was called, and the proxy responded by setting its data accordingly
     XCTAssertEqualObjects(proxy.data, [ModelTestProxy ON_REGISTER_CALLED], @"Expecting proxy.data == [ModelTestProxy ON_REGISTER_CALLED]");
     
+    // Remove the component
     [model removeProxy:proxy.name];
         
+    // Assert that onRemove was called, and the proxy responded by setting its data accordingly
     XCTAssertTrue([proxy.data isEqualToString:[ModelTestProxy ON_REMOVE_CALLED]], @"Expecting proxy.data == [ModelTestProxy ON_REMOVE_CALLED");
 
 }

--- a/PureMVCTests/core/ViewTest.m
+++ b/PureMVCTests/core/ViewTest.m
@@ -27,127 +27,227 @@
 @end
 
 @implementation ViewTest
-
+/**
+Tests the View Multiton Factory Method
+*/
 - (void)testGetInstance {
+    // Test Factory Method
     id<IView> view = [View getInstance:@"ViewTestKey1" factory:^(NSString *key) { return [View withKey:key]; }];
     
+    // Test assertions
     XCTAssertNotNil(view, @"Expecting instance not nil");
     XCTAssertTrue([(id)view conformsToProtocol:@protocol(IView)], @"Expecting instance implements IView");
 }
 
+/**
+A test variable that proves the viewTestMethod was
+invoked by the View.
+*/
 static NSInteger viewTestVar = 0;
 
+/**
+A utility method to test the notification of Observers by the view
+*/
 - (void)viewTestMethod:(id<INotification>)notification {
+    // Set the local viewTestVar to the number on the event payload
     viewTestVar = [(NSNumber *)notification.body integerValue];
 }
 
+/**
+Tests registration and notification of Observers.
+
+An Observer is created to callback the viewTestMethod of
+this ViewTest instance. This Observer is registered with
+the View to be notified of 'ViewTestEvent' events. Such
+an event is created, and a value set on its payload. Then
+the View is told to notify interested observers of this
+Event.
+
+The View calls the Observer's notifyObserver method
+which calls the viewTestMethod on this instance
+of the ViewTest class. The viewTestMethod method will set
+an instance variable to the value passed in on the Event
+payload. We evaluate the instance variable to be sure
+it is the same as that passed out as the payload of the
+original 'ViewTestEvent'.
+*/
 - (void)testRegisterAndNotifyObserver {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey2" factory:^(NSString *key) { return [View withKey:key]; }];
     
+    // Create observer, passing in notification method and context
     id<IObserver> observer = [Observer withNotify:@selector(viewTestMethod:) context:self];
     
+    // Register Observer's interest in a particulat Notification with the View
     [view registerObserver:@"ViewTestNote" observer:observer];
     
+    // Create a ViewTestNote, setting
+    // a body value, and tell the View to notify
+    // Observers. Since the Observer is this class
+    // and the notification method is viewTestMethod,
+    // successful notification will result in our local
+    // viewTestVar being set to the value we pass in
+    // on the note body.
     id<INotification> notification = [Notification withName:@"ViewTestNote" body:@(10)];
     
     [view notifyObservers:notification];
     
+    // Test assertions
     XCTAssertTrue(viewTestVar == 10, @"Expecting viewTestVar == 10");
 }
 
+/**
+Tests registering and retrieving a mediator with
+the View.
+*/
 - (void)testRegisterAndRetrieveMediator {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey3" factory:^(NSString *key) { return [View withKey:key]; }];
     
+    // Create and register the test mediator
     ViewTestMediator *viewTestMediator = [ViewTestMediator withName:ViewTestMediator.NAME];
     [view registerMediator:viewTestMediator];
     
+    // Retrieve the component
     id<IMediator> mediator = [view retrieveMediator:ViewTestMediator.NAME];
     
+    // Test assertions
     XCTAssertNotNil(mediator, @"Mediator should not be nil");
     XCTAssertTrue([(NSObject *)mediator isKindOfClass:[ViewTestMediator class]], @"Expecting mediator type is ViewTestMediator");
     
     XCTAssertEqualObjects(mediator.name, [ViewTestMediator NAME], @"Expecting mediator.name == ViewTestMediator.NAME");
 }
 
+/**
+Tests the hasMediator Method
+*/
 - (void)testHasMediator {
+    // Register a Mediator
     id<IView> view = [View getInstance:@"ViewTestKey4" factory:^(NSString *key){ return [View withKey:key]; }];
     
+    // Create and register the test mediator
     id<IMediator> mediator = [Mediator withName:@"hasMediatorTest" view:self];
     [view registerMediator:mediator];
     
+    // Assert that the view?hasMediator method returns true
+    // for that mediator name
     XCTAssertTrue([view hasMediator:@"hasMediatorTest"] == true, @"Expecting [view hasMediator:@'hasMediatoTest' == true");
     
     [view removeMediator:@"hasMediatorTest"];
     
+    // Assert that the view?hasMediator method returns false
+    // for that mediator name
     XCTAssertTrue([view hasMediator:@"hasMediatorTest"] == false, @"Expecting [view hasMediator:@'hasMediatoTest' == false");
 }
 
+/**
+Tests registering and removing a mediator
+*/
 - (void)testRegisterAndRemoveMediator {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey5" factory:^(NSString *key) { return [View withKey:key]; }];
     
+    // Create and register the test mediator
     id<IMediator> mediator = [Mediator withName:@"testing" view:self];
     [view registerMediator:mediator];
     
+    // Remove the component
     id<IMediator> removedMediator = [view removeMediator:@"testing"];
     
+    // Assert that we have removed the appropriate mediator
     XCTAssertEqualObjects(removedMediator.name, @"testing", @"Expecting removedMediator.name == 'testing'");
     
+    // Assert that the mediator is no longer retrievable
     XCTAssertNil([view retrieveMediator:@"testing"], @"Expecting [view retrieveMediator:@'testing'] == nil");
 }
 
+/**
+Tests that the View callse the onRegister and onRemove methods
+*/
 - (void)testOnRegisterAndOnRemove {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey6" factory:^(NSString *key){ return [View withKey:key]; }];
     
     ViewTestVO *vo = [[ViewTestVO alloc] init];
+    // Create and register the test mediator
     id<IMediator> mediator = [ViewTestMediator4 withView:vo];
     [view registerMediator:mediator];
     
+    // Assert that onRegsiter was called, and the mediator responded by setting our boolean
     XCTAssertTrue(vo.onRegisterCalled == true, @"Expecting vo.onRegisterCalled == true");
     
+    // Remove the component
     [view removeMediator:ViewTestMediator4.NAME];
     
+    // Assert that the mediator is no longer retrievable
     XCTAssertTrue(vo.onRemoveCalled == true, @"Expecting vo.onRemoveCalled == true");
 }
 
+/**
+Tests successive regster and remove of same mediator.
+*/
 - (void)testSuccessiveRegisterAndRemoveMediator {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey7" factory:^(NSString *key){ return [View withKey:key]; }];
     
+    // Create and register the test mediator,
+    // but not so we have a reference to it
     [view registerMediator:[ViewTestMediator withView:self]];
     
+    // Test that we can retrieve it
     XCTAssertTrue([((NSObject *)[view retrieveMediator:ViewTestMediator.NAME]) isKindOfClass:[ViewTestMediator class]]);
     
+    // Remove the Mediator
     [view removeMediator:ViewTestMediator.NAME];
     
+    // Test that retrieving it now returns null
     XCTAssertNil([view retrieveMediator:ViewTestMediator.NAME], @"Expecing [view retrieveMediator:ViewTestMediator.NAME] == nil");
     
+    // Test that removing the mediator again once its gone doesn't cause crash
     XCTAssertNil([view removeMediator:ViewTestMediator.NAME], @"Expecing [view retrieveMediator:ViewTestMediator.NAME] doesn't crash");
     
+    // Create and register another instance of the test mediator,
     [view registerMediator:[ViewTestMediator withView:self]];
     
     XCTAssertTrue([((NSObject *)[view retrieveMediator:ViewTestMediator.NAME]) isKindOfClass:[ViewTestMediator class]]);
     
+    // Remove the Mediator
     [view removeMediator:ViewTestMediator.NAME];
     
+    // Test that retrieving it now returns null
     XCTAssertNil([view retrieveMediator:ViewTestMediator.NAME], @"Expecting [view retrieveMediator:ViewTestMediator.NAME] == nil");
 }
 
+/**
+Tests registering a Mediator for 2 different notifications, removing the
+Mediator from the View, and seeing that neither notification causes the
+Mediator to be notified.
+*/
 - (void)testRemoveMediatorAndSubsequentNotify {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey8" factory:^(NSString *key){ return [View withKey:key]; }];
     
+    // Create and register the test mediator to be removed.
     [view registerMediator:[ViewTestMediator2 withView:self]];
     
     ViewTestVO *vo = [[ViewTestVO alloc] init];
     
+    // Test that notifications work
     [view notifyObservers:[Notification withName:NOTE1 body:vo]];
     XCTAssertEqualObjects(vo.lastNotification, NOTE1, @"Expecting vo.lastNotification == NOTE1");
     
     [view notifyObservers:[Notification withName:NOTE2 body:vo]];
     XCTAssertEqualObjects(vo.lastNotification, NOTE2, @"Expecting vo.lastNotification == NOTE2");
     
+    // Remove the Mediator
     [view removeMediator:ViewTestMediator2.NAME];
     
+    // Test that retrieving it now returns null
     XCTAssertNil([view retrieveMediator:ViewTestMediator2.NAME], @"Expecting [view retrieveMediator:ViewTestMediator2.NAME] == nil");
     
+    // Test that notifications no longer work
+    // (ViewTestMediator2 is the one that sets lastNotification
+    // on this component, and ViewTestMediator)
     vo.lastNotification = nil;
     
     [view notifyObservers:[Notification withName:NOTE1 body:vo]];
@@ -157,15 +257,23 @@ static NSInteger viewTestVar = 0;
     XCTAssertNotEqualObjects(vo.lastNotification, NOTE2, @"Expecting vo.lastNotification != NOTE2");
 }
 
+/**
+Tests registering one of two registered Mediators and seeing
+that the remaining one still responds.
+*/
 - (void)testRemoveOneOfTwoMediatorsAndSubsequentNotify {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey9" factory:^(NSString *key){ return [View withKey:key]; }];
     
+    // Create and register that responds to notifications 1 and 2
     [view registerMediator:[ViewTestMediator2 withView:self]];
     
+    // Create and register that responds to notification 3
     [view registerMediator:[ViewTestMediator3 withView:self]];
     
     ViewTestVO *vo = [[ViewTestVO alloc] init];
     
+    // Test that all notifications work
     [view notifyObservers:[Notification withName:NOTE1 body: vo]];
     XCTAssertEqualObjects(vo.lastNotification, NOTE1, @"Expecting vo.lastNotification == NOTE1");
     
@@ -176,10 +284,14 @@ static NSInteger viewTestVar = 0;
     [view notifyObservers:[Notification withName:NOTE3 body: vo]];
     XCTAssertEqualObjects(vo.lastNotification, NOTE3, @"Expecting vo.lastNotification == NOTE3");
     
+    // Remove the Mediator that responds to 1 and 2
     [view removeMediator:ViewTestMediator2.NAME];
     
+    // Test that retrieving it now returns nil
     XCTAssertNil([view retrieveMediator:ViewTestMediator2.NAME], @"[view retrieveMediator:ViewTestMediator2.NAME] == nil");
     
+    // test that notifications no longer work
+    // for notifications 1 and 2, but still work for 3
     vo.lastNotification = nil;
     
     [view notifyObservers:[Notification withName:NOTE1 body:vo]];
@@ -192,31 +304,59 @@ static NSInteger viewTestVar = 0;
     XCTAssertEqualObjects(vo.lastNotification, NOTE3, @"Expecing vo.lastNotification == NOTE3");
 }
 
+/**
+Tests registering the same mediator twice.
+A subsequent notification should only illicit
+one response. Also, since reregistration
+was causing 2 observers to be created, ensure
+that after removal of the mediator there will
+be no further response.
+*/
 - (void)testMediatorReregistration {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey10" factory:^(NSString *key){ return [View withKey:key]; }];
     
+    // Create and register that responds to notification 5
     [view registerMediator:[ViewTestMediator5 withView:self]];
     
+    // Try to register another instance of that mediator (uses the same NAME constant).
     [view registerMediator:[ViewTestMediator5 withView:self]];
     
+    // Test that the counter is only incremented once (mediator 5's response)
     ViewTestVO *vo = [[ViewTestVO alloc] init];
     vo.counter = 0;
     
     [view notifyObservers:[Notification withName:NOTE5 body:vo]];
     XCTAssertTrue(vo.counter == 1, @"Expecting counter == 1");
     
+    // Remove the Mediator
     [view removeMediator:ViewTestMediator5.NAME];
     
+    // Test that retrieving it now returns nil
     XCTAssertNil([view retrieveMediator:ViewTestMediator5.NAME], @"Expecting [view retrieveMediator:ViewTestMediator5.NAME] == nil");
     
+    // Test that the counter is no longer incremented
     vo.counter = 0;
     [view notifyObservers:[Notification withName:NOTE5 body: vo]];
     XCTAssertTrue(vo.counter == 0, @"Expecting counter == 0");
 }
 
+/**
+Tests the ability for the observer list to
+be modified during the process of notification,
+and all observers be properly notified. This
+happens most often when multiple Mediators
+respond to the same notification by removing
+themselves.
+*/
 - (void)testModifyObserverListDuringNotification {
+    // Get the Multiton View instance
     id<IView> view = [View getInstance:@"ViewTestKey11" factory:^(NSString *key) { return [View withKey:key]; }];
     
+    // Create and register several mediator instances that respond to notification 6
+    // by removing themselves, which will cause the observer list for that notification
+    // to change. versions prior to MultiCore Version 2.0.5 will see every other mediator
+    // fails to be notified.
     ViewTestVO *vo = [[ViewTestVO alloc] init];
     vo.counter = 0;
     
@@ -232,8 +372,11 @@ static NSInteger viewTestVar = 0;
     [view notifyObservers:[Notification withName:NOTE6]];
     // XCTAssertTrue(vo.counter == 8, @"Expecting vo.counter == 8");
     
+    // clear the counter
     vo.counter = 0;
     [view notifyObservers:[Notification withName:NOTE6]];
+    
+    // verify the count is 0
     XCTAssertTrue(vo.counter == 0, @"Expecting vo.counter == 0");
 }
 

--- a/PureMVCTests/core/ViewTestMediator.h
+++ b/PureMVCTests/core/ViewTestMediator.h
@@ -14,6 +14,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A Mediator class used by ViewTest.
+
+`@see org.puremvc.swift.multicore.core.view.ViewTest ViewTest`
+*/
 @interface ViewTestMediator : Mediator
 
 @end

--- a/PureMVCTests/core/ViewTestMediator.m
+++ b/PureMVCTests/core/ViewTestMediator.m
@@ -13,9 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ViewTestMediator
 
+/**
+The Mediator name
+*/
 + (NSString *)NAME { return @"ViewTestMediator"; }
 
 - (NSArray<NSString *> *)listNotificationInterests {
+    // Be sure that the mediator has some Observers created
+    // in order to test removeMediator
     return @[@"ABC", @"DEF", @"GHI"];
 }
 

--- a/PureMVCTests/core/ViewTestMediator2.h
+++ b/PureMVCTests/core/ViewTestMediator2.h
@@ -14,6 +14,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A Mediator class used by ViewTest.
+
+`@see org.puremvc.swift.multicore.core.view.ViewTest ViewTest`
+*/
 @interface ViewTestMediator2 : Mediator
 
 @end

--- a/PureMVCTests/core/ViewTestMediator2.m
+++ b/PureMVCTests/core/ViewTestMediator2.m
@@ -15,9 +15,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ViewTestMediator2
 
+/**
+The Mediator name
+*/
 + (NSString *)NAME { return @"ViewTestMediator2"; }
 
 - (NSArray<NSString *> *)listNotificationInterests {
+    // Be sure that the mediator has some Observers created
+    // in order to test removeMediator
     return @[NOTE1, NOTE2];
 }
 

--- a/PureMVCTests/core/ViewTestMediator3.h
+++ b/PureMVCTests/core/ViewTestMediator3.h
@@ -11,6 +11,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A Mediator class used by ViewTest.
+
+`@see org.puremvc.swift.multicore.core.view.ViewTest ViewTest`
+*/
 @interface ViewTestMediator3 : Mediator
 
 @end

--- a/PureMVCTests/core/ViewTestMediator3.m
+++ b/PureMVCTests/core/ViewTestMediator3.m
@@ -15,12 +15,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ViewTestMediator3
 
+/**
+The Mediator name
+*/
 + (NSString *)NAME { return @"ViewTestMediator3"; }
 
 - (NSArray<NSString *> *)listNotificationInterests {
     return @[NOTE3];
 }
 
+/// Be sure that the mediator has some Observers created in order to test removeMediator
 - (void)handleNotification:(id<INotification>)notification {
     ((ViewTestVO *)notification.body).lastNotification = notification.name;
 }

--- a/PureMVCTests/core/ViewTestMediator4.h
+++ b/PureMVCTests/core/ViewTestMediator4.h
@@ -14,6 +14,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A Mediator class used by ViewTest.
+
+`@see org.puremvc.swift.multicore.core.view.ViewTest ViewTest`
+*/
 @interface ViewTestMediator4 : Mediator
 
 @end

--- a/PureMVCTests/core/ViewTestMediator4.m
+++ b/PureMVCTests/core/ViewTestMediator4.m
@@ -13,6 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ViewTestMediator4
 
+/**
+The Mediator name
+*/
 + (NSString *)NAME { return @"ViewTestMediato4"; }
 
 - (void)onRegister {

--- a/PureMVCTests/core/ViewTestMediator5.h
+++ b/PureMVCTests/core/ViewTestMediator5.h
@@ -14,6 +14,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A Mediator class used by ViewTest.
+
+`@see org.puremvc.swift.core.view.ViewTest ViewTest`
+*/
 @interface ViewTestMediator5 : Mediator
 
 @end

--- a/PureMVCTests/core/ViewTestMediator5.m
+++ b/PureMVCTests/core/ViewTestMediator5.m
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ViewTestMediator5
 
+/**
+The Mediator name
+*/
 + (NSString *)NAME { return @"ViewTestMediator5"; }
 
 - (NSArray<NSString *> *)listNotificationInterests {

--- a/PureMVCTests/core/ViewTestMediator6.h
+++ b/PureMVCTests/core/ViewTestMediator6.h
@@ -14,6 +14,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A Mediator class used by ViewTest.
+
+`@see org.puremvc.swift.core.view.ViewTest ViewTest`
+*/
 @interface ViewTestMediator6 : Mediator
 
 @end

--- a/PureMVCTests/core/ViewTestMediator6.m
+++ b/PureMVCTests/core/ViewTestMediator6.m
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation ViewTestMediator6
 
+/**
+The Mediator base name
+*/
 + (NSString *)NAME { return @"ViewTestMediator6"; }
 
 - (NSArray<NSString *> *)listNotificationInterests {

--- a/PureMVCTests/core/ViewTestNotification.h
+++ b/PureMVCTests/core/ViewTestNotification.h
@@ -8,7 +8,11 @@
 
 #ifndef ViewTestNotification_h
 #define ViewTestNotification_h
+/**
+A Notification class used by ViewTest.
 
+`@see org.puremvc.swift.multicore.core.view.ViewTest ViewTest`
+*/
 typedef NSString * const ViewTestNote NS_TYPED_EXTENSIBLE_ENUM;
 
 static ViewTestNote NOTE1 = @"Notification1";

--- a/PureMVCTests/patterns/command/MacroCommandTest.m
+++ b/PureMVCTests/patterns/command/MacroCommandTest.m
@@ -19,15 +19,47 @@
 
 @implementation MacroCommandTest
 
+/**
+Tests operation of a `MacroCommand`.
+
+This test creates a new `Notification`, adding a
+`MacroCommandTestVO` as the body.
+It then creates a `MacroCommandTestCommand` and invokes
+its `execute` method, passing in the
+`Notification`.
+
+The `MacroCommandTestCommand` has defined an
+`initializeMacroCommand` method, which is
+called automatically by its constructor. In this method
+the `MacroCommandTestCommand` adds 2 SubCommands
+to itself, `MacroCommandTestSub1Command` and
+`MacroCommandTestSub2Command`.
+
+The `MacroCommandTestVO` has 2 result properties,
+one is set by `MacroCommandTestSub1Command` by
+multiplying the input property by 2, and the other is set
+by `MacroCommandTestSub2Command` by multiplying
+the input property by itself.
+
+Success is determined by evaluating the 2 result properties
+on the `MacroCommandTestVO` that was passed to
+the `MacroCommandTestCommand` on the Notification
+body.
+*/
 - (void)testMacroCommandExecute {
+    // Create the VO
     MacroCommandTestVO *vo = [[MacroCommandTestVO alloc] initWithInput:5];
     
+    // Create the Notification (note)
     id<INotification> note = [Notification withName:@"MacroCommandTest" body: vo];
     
+    // Create the MacroCommand
     id<ICommand> command = [MacroCommandTestCommand command];
     
+    // Execute the MacroCommand
     [command execute:note];
     
+    // Test assertions
     XCTAssertTrue(vo.result1 == 10, @"Expecting v.result1 == 10");
     XCTAssertTrue(vo.result2 == 25, @"Expecting v.result2 == 25");
 }

--- a/PureMVCTests/patterns/command/MacroCommandTestCommand.h
+++ b/PureMVCTests/patterns/command/MacroCommandTestCommand.h
@@ -14,6 +14,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A MacroCommand subclass used by MacroCommandTest.
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTest MacroCommandTest`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTestSub1Command MacroCommandTestSub1Command`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTestSub2Command MacroCommandTestSub2Command`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTestVO MacroCommandTestVO`
+*/
 @interface MacroCommandTestCommand : MacroCommand
 
 @end

--- a/PureMVCTests/patterns/command/MacroCommandTestCommand.m
+++ b/PureMVCTests/patterns/command/MacroCommandTestCommand.m
@@ -16,6 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MacroCommandTestCommand
 
+/**
+Initialize the MacroCommandTestCommand by adding
+its 2 SubCommands.
+*/
 - (void)initializeMacroCommand {
     [self addSubCommand:^id<ICommand> { return [MacroCommandTestSub1Command command]; } ];
     [self addSubCommand:^id<ICommand> { return [MacroCommandTestSub2Command command]; } ];

--- a/PureMVCTests/patterns/command/MacroCommandTestSub1Command.m
+++ b/PureMVCTests/patterns/command/MacroCommandTestSub1Command.m
@@ -14,8 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MacroCommandTestSub1Command
 
+/**
+Fabricate a result by multiplying the input by 2
+
+- parameter event: the `IEvent` carrying the `MacroCommandTestVO`
+*/
 - (void)execute:(id<INotification>)notification {
     MacroCommandTestVO *vo = [notification body];
+    
+    // Fabricate a result
     vo.result1 = 2 * vo.input;
 }
 

--- a/PureMVCTests/patterns/command/MacroCommandTestSub2Command.m
+++ b/PureMVCTests/patterns/command/MacroCommandTestSub2Command.m
@@ -14,8 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MacroCommandTestSub2Command
 
+/**
+Fabricate a result by multiplying the input by itself
+
+- parameter event: the `IEvent` carrying the `MacroCommandTestVO`
+*/
 - (void)execute:(id<INotification>)notification {
     MacroCommandTestVO *vo = [notification body];
+    
+    // Fabricate a result
     vo.result2 = vo.input * vo.input;
 }
 

--- a/PureMVCTests/patterns/command/MacroCommandTestVO.h
+++ b/PureMVCTests/patterns/command/MacroCommandTestVO.h
@@ -13,6 +13,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A utility class used by MacroCommandTest.
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTest MacroCommandTest`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTestCommand MacroCommandTestCommand`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTestSub1Command MacroCommandTestSub1Command`
+
+`@see org.puremvc.swift.multicore.patterns.command.MacroCommandTestSub2Command MacroCommandTestSub2Command`
+*/
 @interface MacroCommandTestVO : NSObject
 
 @property (nonatomic, assign, readonly) int input;

--- a/PureMVCTests/patterns/command/MacroCommandTestVO.m
+++ b/PureMVCTests/patterns/command/MacroCommandTestVO.m
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MacroCommandTestVO
 
+/**
+Constructor.
+*
+- parameter input: the number to be fed to the MacroCommandTestCommand
+*/
 - (instancetype)initWithInput:(int)input {
     if(self = [super init]) {
         _input = input;

--- a/PureMVCTests/patterns/command/SimpleCommandTest.m
+++ b/PureMVCTests/patterns/command/SimpleCommandTest.m
@@ -19,15 +19,32 @@
 
 @implementation SimpleCommandTest
 
+/**
+Tests the `execute` method of a `SimpleCommand`.
+
+This test creates a new `Notification`, adding a
+`SimpleCommandTestVO` as the body.
+It then creates a `SimpleCommandTestCommand` and invokes
+its `execute` method, passing in the note.
+
+Success is determined by evaluating a property on the
+object that was passed on the Notification body, which will
+be modified by the SimpleCommand.
+*/
 - (void)testSimpleCommandExecute {
+    // Create the VO
     SimpleCommandTestVO *vo = [[SimpleCommandTestVO alloc] initWithInput:5];
     
+    // Create the Notification (note)
     id<INotification> note = [Notification withName:@"SimpleCommandTest" body:vo];
     
+    // Create the SimpleCommand
     id<ICommand> command = [SimpleCommandTestCommand command];
     
+    // Execute the SimpleCommand
     [command execute:note];
     
+    // Test assertions
     XCTAssertTrue(vo.result == 10, @"Expecting vo.result == 10");
 }
 @end

--- a/PureMVCTests/patterns/command/SimpleCommandTestCommand.h
+++ b/PureMVCTests/patterns/command/SimpleCommandTestCommand.h
@@ -14,6 +14,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A SimpleCommand subclass used by SimpleCommandTest.
+
+`@see org.puremvc.swift.multicore.patterns.command.SimpleCommandTest SimpleCommandTest`
+`@see org.puremvc.swift.multicore.patterns.command.SimpleCommandTestVO SimpleCommandTestVO`
+*/
 @interface SimpleCommandTestCommand : SimpleCommand
 
 @end

--- a/PureMVCTests/patterns/command/SimpleCommandTestCommand.m
+++ b/PureMVCTests/patterns/command/SimpleCommandTestCommand.m
@@ -14,8 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SimpleCommandTestCommand
 
+/**
+Fabricate a result by multiplying the input by 2
+
+- parameter event: the `INotification` carrying the `SimpleCommandTestVO`
+*/
 - (void)execute:(id<INotification>)notification {
     SimpleCommandTestVO *vo = [notification body];
+    
+    //Fabricate a result
     vo.result = 2 * vo.input;
 }
 

--- a/PureMVCTests/patterns/command/SimpleCommandTestVO.h
+++ b/PureMVCTests/patterns/command/SimpleCommandTestVO.h
@@ -11,6 +11,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A utility class used by SimpleCommandTest.
+
+`@see org.puremvc.swift.multicore.patterns.command.SimpleCommandTest SimpleCommandTest`
+
+`@see org.puremvc.swift.multicore.patterns.command.SimpleCommandTestCommand SimpleCommandTestCommand`
+*/
 @interface SimpleCommandTestVO : NSObject
 
 @property (nonatomic) int input;

--- a/PureMVCTests/patterns/command/SimpleCommandTestVO.m
+++ b/PureMVCTests/patterns/command/SimpleCommandTestVO.m
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SimpleCommandTestVO
 
+/**
+Constructor.
+
+- parameter input: the number to be fed to the SimpleCommandTestCommand
+*/
 - (instancetype) initWithInput:(int)input {
     if (self = [super init]) {
         _input = input;

--- a/PureMVCTests/patterns/facade/FacadeTest.m
+++ b/PureMVCTests/patterns/facade/FacadeTest.m
@@ -22,43 +22,96 @@
 
 @implementation FacadeTest
 
+/**
+Tests the Facade Multiton Factory Method
+*/
 - (void)testGetInstance {
+    // Test Factory Method
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey1" factory:^(NSString *key) { return [Facade withKey:key]; }];
     // id<IFacade> facade = [Facade getInstance:@"FacadeTestKey1" factory:^id<IFacade>(NSString *key) { return [Facade withKey:key]; }];
     
+    // Test assertions
     XCTAssertNotNil(facade, @"Expecting instance not nil");
     XCTAssertTrue([(id)facade conformsToProtocol:@protocol(IFacade)], @"Expecting instance implements IFacade");
 }
 
+/**
+Tests Command registration and execution via the Facade.
+
+This test gets a Multiton Facade instance
+and registers the FacadeTestCommand class
+to handle 'FacadeTest' Notifcations.
+
+It then sends a notification using the Facade.
+Success is determined by evaluating
+a property on an object placed in the body of
+the Notification, which will be modified by the Command.
+*/
 - (void)testRegisterCommandAndSendNotification {
+    // Create the Facade, register the FacadeTestCommand to
+    // handle 'FacadeTest' notifications
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey2" factory:^(NSString *key) { return [Facade withKey:key]; }];
     [facade registerCommand:@"FacadeTestNote" factory:^() { return [FacadeTestCommand command]; }];
     
+    // Send notification. The Command associated with the event
+    // (FacadeTestCommand) will be invoked, and will multiply
+    // the vo.input value by 2 and set the result on vo.result
     FacadeTestVO *vo = [[FacadeTestVO alloc] initWithInput:32];
     [facade sendNotification:@"FacadeTestNote" body:vo type:nil];
 
+    // Test assertions
     XCTAssertTrue(vo.result == 64, @"Expecting vo.result == 64");
 }
 
+/**
+Tests Command removal via the Facade.
+
+This test gets a Multiton Facade instance
+and registers the FacadeTestCommand class
+to handle 'FacadeTest' Notifcations. Then it removes the command.
+
+It then sends a Notification using the Facade.
+Success is determined by evaluating
+a property on an object placed in the body of
+the Notification, which will NOT be modified by the Command.
+*/
 - (void)testRegisterAndRemoveCommandAndSendNotification {
+    // Create the Facade, register the FacadeTestCommand to
+    // handle 'FacadeTest' events
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey3" factory:^(NSString *key) { return [Facade withKey:key]; }];
     [facade registerCommand:@"FacadeTestNote" factory:^() { return [FacadeTestCommand command]; }];
     [facade removeCommand:@"FacadeTestNote"];
     
+    // Send notification. The Command associated with the event
+    // (FacadeTestCommand) will NOT be invoked, and will NOT multiply
+    // the vo.input value by 2
     FacadeTestVO *vo = [[FacadeTestVO alloc] initWithInput:32];
     [facade sendNotification:@"FacadeTestNote" body:vo type:nil];
     
+    // Test assertions
     XCTAssertTrue(vo.result != 64, @"Expecting vo.result != 64");
 }
 
+/**
+Tests the regsitering and retrieving Model proxies via the Facade.
+
+Tests `registerProxy` and `retrieveProxy` in the same test.
+These methods cannot currently be tested separately
+in any meaningful way other than to show that the
+methods do not throw exception when called.
+*/
 - (void)testRegisterAndRetrieveProxy {
+    // Register a proxy and retrieve it.
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey4" factory:^(NSString *key) { return [Facade withKey:key]; }];
     [facade registerProxy:[Proxy withName:@"colors" data:@[@"red", @"green", @"blue"]]];
     id<IProxy> proxy = [facade retrieveProxy:@"colors"];
     
     XCTAssertTrue([(id)proxy conformsToProtocol:@protocol(IProxy)], @"Expecting instance implements IProxy");
     
+    // Retrieve data from proxy
     NSArray<NSString *> *data = proxy.data;
+    
+    // Test assertions
     XCTAssertNotNil(proxy, @"Expecting proxy not to be nil");
     XCTAssertEqual(3, data.count, @"Expecting data.count == 3");
     XCTAssertEqualObjects(data[0], @"red", "Expecting data[0] == 'red'");
@@ -66,73 +119,118 @@
     XCTAssertEqualObjects(data[2], @"blue", @"Expecting data[0] == 'blue'");
 }
 
+/**
+Tests the removing Proxies via the Facade.
+*/
 - (void)testRegisterAndRemoveProxy {
+    // Register a proxy, remove it, then try to retrieve it
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey5" factory:^(NSString *key) { return [Facade withKey:key]; }];
     id<IProxy> proxy = [Proxy withName:@"sizes" data:@[@(7), @(13), @(21)]];
     [facade registerProxy:proxy];
     
+    // Remove the proxy
     id<IProxy> removedProxy = [facade removeProxy:@"sizes"];
     
+    // Assert that we removed the appropriate proxy
     XCTAssertEqualObjects(removedProxy.name, @"sizes", @"Expecting removedProxy.name == 'sizes'");
     
+    // Make sure we can no longer retrieve the proxy from the model
     proxy = [facade retrieveProxy:@"sizes"];
     
+    // Test assertions
     XCTAssertNil(proxy, @"Expecting proxy is nil");
 }
 
+/**
+Tests registering, retrieving and removing Mediators via the Facade.
+*/
 - (void)testRegisterRetrieveAndRemoveMediator {
+    // Register a mediator, remove it, then try to retrieve it
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey6" factory:^(NSString *key) { return [Facade withKey:key]; }];
     
     [facade registerMediator:[Mediator withName:Mediator.NAME view:[[NSObject alloc] init]]];
     
+    // Retrieve the mediator
     XCTAssertNotNil([facade retrieveMediator:Mediator.NAME], @"Expecting mediator is not nil");
     
+    // Remove the mediator
     id<IMediator> removedMediator = [facade removeMediator:Mediator.NAME];
     
+    // Assert that we have removed the appropriate mediator
     XCTAssertEqualObjects(removedMediator.name, Mediator.NAME, @"Expecting removedMediator.name == Mediator.NAME");
     
+    // Assert that the mediator is no longer retrievable
     XCTAssertNil([facade retrieveMediator:Mediator.NAME], @"Expecting [facade retrieveMediator:Mediator.NAME] == nil");
 }
 
+/**
+Tests the hasProxy Method
+*/
 - (void)testHasProxy {
+    // Register a Proxy
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey7" factory:^(NSString *key) { return [Facade withKey:key]; }];
     [facade registerProxy:[Proxy withName:@"hasProxyTest" data:@[@(1), @(2), @(3)]]];
     
+    // Assert that the model.hasProxy method returns true
+    // for that proxy name
     XCTAssertTrue([facade hasProxy:@"hasProxyTest"], @"Expecing [facade hasProxy:@'hasProxyTest'] == true");
 }
 
+/**
+Tests the hasMediator Method
+*/
 - (void)testHasMediator {
+    // Register a Mediator
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey8" factory:^(NSString *key) { return [Facade withKey:key]; }];
     [facade registerMediator:[Mediator withName:@"facadeHasMediatorTest" view:[[NSObject alloc] init]]];
     
+    // Assert that the facade?.hasMediator method returns true
+    // for that mediator name
     XCTAssertTrue([facade hasMediator:@"facadeHasMediatorTest"], @"Expecting [facade hasMediator:@'facadeHasMediatorTest'] == true");
     
     [facade removeMediator:@"facadeHasMediatorTest"];
     
+    // Assert that the facade?.hasMediator method returns false
+    // for that mediator name
     XCTAssertFalse([facade hasMediator:@"facadeHasMediatorTest"], @"Expecting [facade hasMediator:@'facadeHasMediatorTest'] == false");
 }
 
+/**
+Test hasCommand method.
+*/
 - (void)testHasCommand {
+    // Register the ControllerTestCommand to handle 'hasCommandTest' notes
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey9" factory:^(NSString *key) { return [Facade withKey:key]; }];
     [facade registerCommand:@"facadeHasCommandTest" factory:^() { return [FacadeTestCommand command]; } ];
     
+    // Test that hasCommand returns true for hasCommandTest notifications
     XCTAssertTrue([facade hasCommand:@"facadeHasCommandTest"], @"Expecting [facade hasCommand:@'facadeHasCommandTest'] == true");
     
+    // Remove the Command from the Controller
     [facade removeCommand:@"facadeHasCommandTest"];
     
+    // Test that hasCommand returns false for hasCommandTest notifications
     XCTAssertFalse([facade hasCommand:@"facadeHasCommandTest"], @"Expecting [facade hasCommand:@'facadeHasCommandTest'] == false");
 }
 
+/**
+Tests the hasCore and removeCore methods
+*/
 - (void)testHasCoreAndRemoveCore {
+    // Assert that the Facade.hasCore method returns false first
     XCTAssertFalse([Facade hasCore:@"FacadeTestKey10"], @"Expecing [Facade hasCore:@'FacadeTestKey10'] == false");
+    
+    // Register a Core
     id<IFacade> facade = [Facade getInstance:@"FacadeTestKey10" factory:^(NSString *key) { return [Facade withKey:key]; }];
     
+    // Assert that the Facade.hasCore method returns true now that a Core is registered
     XCTAssertNotNil(facade, @"Expecting instance not nil");
-    
     XCTAssertTrue([Facade hasCore:@"FacadeTestKey10"], @"Expecing [Facade hasCore:@'FacadeTestKey10'] == true");
     
+    // remove the Core
     [Facade removeCore:@"FacadeTestKey10"];
     
+    // Assert that the Facade.hasCore method returns false now that the core has been removed.
     XCTAssertFalse([Facade hasCore:@"FacadeTestKey10"], @"Expecing [Facade hasCore:@'FacadeTestKey10'] == false");
 }
 

--- a/PureMVCTests/patterns/facade/FacadeTestCommand.h
+++ b/PureMVCTests/patterns/facade/FacadeTestCommand.h
@@ -14,6 +14,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A SimpleCommand subclass used by FacadeTest.
+
+`@see org.puremvc.swift.multicore.patterns.facade.FacadeTest FacadeTest`
+
+`@see org.puremvc.swift.multicore.patterns.facade.FacadeTestVO FacadeTestVO`
+*/
 @interface FacadeTestCommand : SimpleCommand
 
 @end

--- a/PureMVCTests/patterns/facade/FacadeTestCommand.m
+++ b/PureMVCTests/patterns/facade/FacadeTestCommand.m
@@ -14,9 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FacadeTestCommand
 
+/**
+Fabricate a result by multiplying the input by 2
+
+- parameter note: the Notification carrying the FacadeTestVO
+*/
 - (void)execute:(id<INotification>)notification {
     FacadeTestVO *vo = notification.body;
     
+    // Fabricate a result
     vo.result = 2 * vo.input;
 }
 

--- a/PureMVCTests/patterns/facade/FacadeTestVO.h
+++ b/PureMVCTests/patterns/facade/FacadeTestVO.h
@@ -13,6 +13,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+A utility class used by FacadeTest.
+
+`@see org.puremvc.swift.multicore.patterns.facade.FacadeTest FacadeTest`
+
+`@see org.puremvc.swift.multicore.patterns.facade.FacadeTestCommand FacadeTestCommand`
+*/
 @interface FacadeTestVO : NSObject
 
 @property (nonatomic, assign, readonly) int input;

--- a/PureMVCTests/patterns/facade/FacadeTestVO.m
+++ b/PureMVCTests/patterns/facade/FacadeTestVO.m
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FacadeTestVO
 
+/**
+Constructor.
+
+- parameter input: the number to be fed to the FacadeTestCommand
+*/
 - (instancetype)initWithInput:(int)input {
     if (self = [super init]) {
         _input = input;

--- a/PureMVCTests/patterns/mediator/MediatorTest.m
+++ b/PureMVCTests/patterns/mediator/MediatorTest.m
@@ -16,18 +16,29 @@
 
 @implementation MediatorTest
 
+/**
+Tests getting the name using Mediator class accessor method.
+*/
 - (void)testNameAccessor {
+    // Create a new Mediator and use accessors to set the mediator name
     id<IMediator> mediator = [Mediator mediator];
     
+    // Test assertions
     XCTAssertEqualObjects(mediator.name, [Mediator NAME], @"Expecting mediator.name == [Mediator NAME]");
 
 }
 
+/**
+Tests getting the name using Mediator class accessor method.
+*/
 - (void)testViewAccessor {
+    // Create a view object
     id object = [[NSObject alloc] init];
     
+    // Create a new Proxy and use accessors to set the proxy name
     id<IMediator> mediator = [Mediator withName:@"MyMediator" view:object];
     
+    // Test assertions
     XCTAssertNotNil([mediator view], @"Expecting view not nill");
 }
 

--- a/PureMVCTests/patterns/observer/NotificationTest.m
+++ b/PureMVCTests/patterns/observer/NotificationTest.m
@@ -16,22 +16,34 @@
 
 @implementation NotificationTest
 
+/**
+Tests setting and getting the name using Notification class accessor methods.
+*/
 - (void)testNameAccessors {
+    // Create a new Notification and use accessors to set the note name
     id<INotification> notification = [Notification withName:@"TestNote"];
     
+    // Test assertions
     XCTAssertEqualObjects(notification.name, @"TestNote", @"Expecting notification.name == 'TestNote'");
 }
 
+/**
+Tests setting and getting the body using Notification class accessor methods.
+*/
 - (void)testBodyAccessors {
+    // Create a new Notification and use accessors to set the body
     id<INotification> notification = [Notification withName:@"TestNote"];
     notification.body = @(5);
     
+    // Test assertions
     XCTAssertTrue([[notification body] intValue] == 5, @"Expecting [notification body] == 5");
 }
 
 - (void)testConstructor {
+    // Create a new Notification using the Constructor to set the note name and body
     id<INotification> notification = [Notification withName:@"TestNote" body:@(5) type:@"TestNoteType"];
     
+    // Test assertions
     XCTAssertEqualObjects(notification.name, @"TestNote", @"Expecting notification.name == 'TestNote'");
     XCTAssertTrue([notification.body intValue], @"Expecting [notification body] == 5");
     
@@ -39,10 +51,15 @@
 
 }
 
+/**
+Tests the toString method of the notification
+*/
 - (void)testDescription {
+    // Create a new Notification and use accessors to set the note name
     id<INotification> notification = [Notification withName:@"TestNote" body:@"1,3,5" type:@"TestType"];
     NSString *ts = @"Notification Name: TestNote\nBody: 1,3,5\nType: TestType";
     
+    // Test assertions
     XCTAssertEqualObjects(notification.description, ts, @"Expecing note.description == ts");
 }
 

--- a/PureMVCTests/patterns/observer/NotifierTest.m
+++ b/PureMVCTests/patterns/observer/NotifierTest.m
@@ -22,6 +22,9 @@
 
 @implementation NotifierTest
 
+/**
+Tests notifier methods.
+*/
 - (void)testNotifier {
     id<INotifier> notifier = [[Notifier alloc] init];
     [notifier initializeNotifier:@"NotifierTestKey1"];

--- a/PureMVCTests/patterns/observer/ObserverTest.m
+++ b/PureMVCTests/patterns/observer/ObserverTest.m
@@ -20,35 +20,66 @@ static NSInteger observerTestVar = 0;
 
 @implementation ObserverTest
 
+/**
+A test variable that proves the notify method was
+executed with 'this' as its exectution context
+*/
 - (void)observerTestMethod:(id<INotification>)notification {
     observerTestVar = [(NSNumber *)notification.body integerValue];
 }
 
+/**
+Tests observer class when initialized by accessor methods.
+*/
 - (void)testObserverAccessors {
+    // Create observer
     id<IObserver> observer = [Observer withNotify:nil context:nil];
     observer.context = self;
     observer.notify = @selector(observerTestMethod:);
     
+    // Create a test event, setting a payload value and notify
+    // the observer with it. since the observer is this class
+    // and the notification method is observerTestMethod,
+    // successful notification will result in our local
+    // observerTestVar being set to the value we pass in
+    // on the note body.
     id<INotification> notification = [Notification withName:@"ObserverTestNote" body:@(10)];
     [observer notifyObserver:notification];
     
+    // Test assertions
     XCTAssertTrue(observerTestVar == 10, @"Expecting observerTestVar == 10");
 }
 
+/**
+Tests observer class when initialized by constructor.
+*/
 - (void)testObserverConstructor {
+    // Create observer passing in notification method and context
     id<IObserver> observer = [Observer withNotify:@selector(observerTestMethod:) context:self];
     
+    // Create a test note, setting a body value and notify
+    // the observer with it. since the observer is this class
+    // and the notification method is observerTestMethod,
+    // successful notification will result in our local
+    // observerTestVar being set to the value we pass in
+    // on the note body.
     id<INotification> notification = [Notification withName:@"ObserverTestNote" body:@(5)];
     [observer notifyObserver:notification];
     
+    // Test assertions
     XCTAssertTrue(observerTestVar == 5, "Expecting observerTestVar == 5");
 }
 
+/**
+Tests the compareNotifyContext method of the Observer class
+*/
 - (void)testCompareNotifyContext {
+    // Create observer passing in notification method and context
     id<IObserver> observer = [Observer withNotify:@selector(observerTestMethod:) context:self];
     
     NSObject *negTestObject = [[NSObject alloc] init];
     
+    // Test assertions
     XCTAssertFalse([observer compareNotifyContext:negTestObject], @"[observer compareNotifyContext:negTestObject] == false");
     XCTAssertTrue([observer compareNotifyContext:self], @"[observer compareNotifyContext:self]");
 }

--- a/PureMVCTests/patterns/proxy/ProxyTest.m
+++ b/PureMVCTests/patterns/proxy/ProxyTest.m
@@ -16,19 +16,29 @@
 
 @implementation PureMVCTest
 
+/**
+Tests getting the name using Proxy class accessor method. Setting can only be done in constructor.
+*/
 - (void)testNameAccessor {
+    // Create a new Proxy and use accessors to set the proxy name
     id<IProxy> proxy = [Proxy withName:@"TestProxy"];
     
+    // Test assertions
     XCTAssertNotNil(proxy, @"Expectin proxy not to be nil");
     XCTAssertEqualObjects([proxy name], @"TestProxy", @"Expecting [proxy name] == 'TestProxy'");
 }
 
+/**
+Tests setting and getting the data using Proxy class accessor methods.
+*/
 - (void)testDataAccessor {
+    // Create a new Proxy and use accessors to set the data
     id<IProxy> proxy = [Proxy withName:@"colors"];
     proxy.data = @[@"red", @"green", @"blue"];
     
     NSArray *data = [proxy data];
     
+    // Test assertions
     XCTAssertNotNil(proxy, @"Expecting proxy not to be nil");
     XCTAssertEqual(3, data.count, @"Expecting data.count == 3");
     XCTAssertEqualObjects(data[0], @"red", "Expecting data[0] == 'red'");
@@ -36,10 +46,15 @@
     XCTAssertEqualObjects(data[2], @"blue", @"Expecting data[0] == 'blue'");
 }
 
+/**
+Tests setting the name and body using the Notification class Constructor.
+*/
 - (void)testConstructor {
+    // Create a new Proxy using the Constructor to set the name and data
     Proxy *proxy = [Proxy withName:@"colors" data:@[@"red", @"green", @"blue"]];
     NSArray *data = [proxy data];
     
+    // Test assertions
     XCTAssertNotNil(proxy, @"Expecting proxy not to be nil");
     XCTAssertEqualObjects([proxy name], @"colors", @"Expecting [proxy name] == 'colors'");
     XCTAssertNotNil(data, @"Expecting data not be nil");


### PR DESCRIPTION
### What?
This PR brings the Objective-C documentation into exact parity with our Swift sources, ensuring every public API and test class carries the same docblocks and commentary.

### Why?
* Maintain a single source of truth for documentation across both language targets
* Improve consistency in Xcode Quick Help and generated API docs
* Ensure every class, method, protocol, and test is fully documented

### How?
* Copied each Swift `/** … */` docblock verbatim into the corresponding Objective-C header or implementation, preserving parameter and return annotations
* Added missing class-level comments above each `@interface`/`@implementation` in the test suites to match the Swift top-level descriptions
* Used `/** … */` for all multi-line API comments and `//` for internal implementation notes.
